### PR TITLE
chore: change monorepo name to avoid collisions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: coverde
+name: coverde_monorepo
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Details

Change monorepo name to avoid collisions that end up affecting Pub scores.