### PR TITLE
test(coverde): filter raw pattern case

### DIFF
--- a/packages/coverde_cli/test/src/commands/filter/fixtures/.gitignore
+++ b/packages/coverde_cli/test/src/commands/filter/fixtures/.gitignore
@@ -1,1 +1,2 @@
-filtered.lcov.info
+unquoted.filtered.lcov.info
+raw.filtered.lcov.info


### PR DESCRIPTION
## Details

Add test case for trace file filtering that receives a raw pattern as input.