### PR TITLE
ci: use token-based uploads for Codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,6 +88,7 @@ jobs:
       - name: Upload coverage data to Codecov
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: filtered.lcov.info
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
## Details

Upload coverage trace files to Codecov using a token-based method.