### PR TITLE
refactor(coverde,pag,pdg,psc): solve lints

### DIFF
--- a/packages/coverde_cli/analysis_options.yaml
+++ b/packages/coverde_cli/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:very_good_analysis/analysis_options.2.0.0.yaml
+include: package:very_good_analysis/analysis_options.yaml
 
 analyzer:
   exclude:

--- a/packages/coverde_cli/lib/coverde.dart
+++ b/packages/coverde_cli/lib/coverde.dart
@@ -1,3 +1,4 @@
+/// Coverde CLI package.
 library coverde;
 
 export 'src/commands/coverde.dart';

--- a/packages/coverde_cli/lib/src/commands/filter/filter.dart
+++ b/packages/coverde_cli/lib/src/commands/filter/filter.dart
@@ -33,7 +33,6 @@ Destination coverage info file to dump the resulting coverage data into.''',
         help: '''
 Path to be used to prefix all the paths in the resulting coverage trace file.''',
         valueHelp: _pathsParentHelpValue,
-        mandatory: false,
       )
       ..addMultiOption(
         filtersOption,
@@ -164,7 +163,7 @@ If an absolute path is found in the coverage trace file, the process will fail.'
       } else {
         if (path.isAbsolute(fileCovData.source.path) && pathsParent != null) {
           usageException(
-            'The `$pathsParentOption` option cannot be used with trace files'
+            'The `$pathsParentOption` option cannot be used with trace files '
             'that contain absolute paths.',
           );
         }

--- a/packages/coverde_cli/lib/src/commands/report/report.dart
+++ b/packages/coverde_cli/lib/src/commands/report/report.dart
@@ -116,11 +116,11 @@ Generate the coverage report inside $_outputHelpValue from the $_inputHelpValue 
   @override
   Future<void> run() async {
     // Retrieve arguments and validate their value and the state they represent.
-    final _traceFilePath = checkOption(
+    final traceFilePath = checkOption(
       optionKey: inputOption,
       optionName: 'input trace file',
     );
-    final _reportDirPath = path.joinAll(
+    final reportDirPath = path.joinAll(
       path.split(
         checkOption(
           optionKey: outputOption,
@@ -146,12 +146,12 @@ Generate the coverage report inside $_outputHelpValue from the $_inputHelpValue 
     );
 
     // Report dir path should be absolute.
-    final reportDirAbsPath = path.isAbsolute(_reportDirPath)
-        ? _reportDirPath
-        : path.join(Directory.current.path, _reportDirPath);
-    final traceFileAbsPath = path.isAbsolute(_traceFilePath)
-        ? _traceFilePath
-        : path.join(Directory.current.path, _traceFilePath);
+    final reportDirAbsPath = path.isAbsolute(reportDirPath)
+        ? reportDirPath
+        : path.join(Directory.current.path, reportDirPath);
+    final traceFileAbsPath = path.isAbsolute(traceFilePath)
+        ? traceFilePath
+        : path.join(Directory.current.path, traceFilePath);
 
     final traceFile = File(traceFileAbsPath);
 

--- a/packages/coverde_cli/lib/src/commands/rm/rm.dart
+++ b/packages/coverde_cli/lib/src/commands/rm/rm.dart
@@ -64,11 +64,9 @@ Remove a set of files and folders.''';
         case FileSystemEntityType.directory:
           final dir = Directory(elementPath);
           dir.deleteSync(recursive: true);
-          break;
         case FileSystemEntityType.file:
           final file = File(elementPath);
           file.deleteSync(recursive: true);
-          break;
         case FileSystemEntityType.notFound:
           final message = 'The <$elementPath> element does not exist.';
           if (shouldAcceptAbsence) {

--- a/packages/coverde_cli/lib/src/utils/command.dart
+++ b/packages/coverde_cli/lib/src/utils/command.dart
@@ -1,7 +1,7 @@
 import 'package:args/command_runner.dart';
 
 /// Extended utils on the command implementation.
-extension ExtendedCommand on Command {
+extension ExtendedCommand on Command<void> {
   /// Validate command multi-options.
   List<String> checkMultiOption({
     required String multiOptionKey,

--- a/packages/coverde_cli/pubspec.yaml
+++ b/packages/coverde_cli/pubspec.yaml
@@ -40,13 +40,13 @@ dev_dependencies:
   build_verify: ^3.1.0
   csslib: ^1.0.0
   mocktail: ^1.0.0
-  pubspec_parse: ^1.2.3
-  test: ^1.24.6
-  very_good_analysis: ^5.0.0+1
   package_assets_generator:
     path: ../package_assets_generator
   package_data_generator:
     path: ../package_data_generator
+  pubspec_parse: ^1.2.3
+  test: ^1.24.6
+  very_good_analysis: ^5.0.0+1
 
 executables:
   coverde:

--- a/packages/coverde_cli/test/ensure_up_to_date_src_gen_test.dart
+++ b/packages/coverde_cli/test/ensure_up_to_date_src_gen_test.dart
@@ -1,4 +1,6 @@
 @Tags(['ci-only'])
+library coverde_cli.test.ensure_up_to_date_src_gen_test;
+
 import 'package:build_verify/build_verify.dart';
 import 'package:test/test.dart';
 

--- a/packages/coverde_cli/test/src/commands/filter/filter_test.dart
+++ b/packages/coverde_cli/test/src/commands/filter/filter_test.dart
@@ -76,7 +76,7 @@ THEN a filtered trace file should be created
           // ARRANGE
           final directory =
               Directory.systemTemp.createTempSync('coverde-filter-test-');
-          const patterns = <String>[r'ignored_source'];
+          const patterns = <String>['ignored_source'];
           final patternsRegex = patterns.map(RegExp.new);
           final originalFilePath = path.joinAll([
             directory.path,
@@ -187,7 +187,7 @@ THEN a filtered trace file should be created
           // ARRANGE
           final directory =
               Directory.systemTemp.createTempSync('coverde-filter-test-');
-          const patterns = <String>[r'ignored_source'];
+          const patterns = <String>['ignored_source'];
           final patternsRegex = patterns.map(RegExp.new);
           final originalFilePath = path.join(
             directory.path,
@@ -301,7 +301,7 @@ THEN a filtered trace file should be created
           // ARRANGE
           final directory =
               Directory.systemTemp.createTempSync('coverde-filter-test-');
-          const patterns = <String>[r'ignored_source'];
+          const patterns = <String>['ignored_source'];
           final pathsPrefix = path.join('root', 'parent');
           final patternsRegex = patterns.map(RegExp.new);
           final originalFilePath = path.join(
@@ -423,7 +423,7 @@ AND no filtered file should be created
           // ARRANGE
           final directory =
               Directory.systemTemp.createTempSync('coverde-filter-test-');
-          const patterns = <String>[r'ignored_source'];
+          const patterns = <String>['ignored_source'];
           final pathsPrefix = path.join('root', 'parent');
           final originalFilePath = path.join(
             directory.path,
@@ -528,7 +528,7 @@ THEN an error indicating the issue should be thrown
           // ARRANGE
           final directory =
               Directory.systemTemp.createTempSync('coverde-filter-test-');
-          const patterns = <String>[r'ignored_source'];
+          const patterns = <String>['ignored_source'];
           final absentFilePath = path.join(
             directory.path,
             'absent.info',

--- a/packages/coverde_cli/test/src/commands/report/fixtures/fake_project_2/lib/fake_project_2.dart
+++ b/packages/coverde_cli/test/src/commands/report/fixtures/fake_project_2/lib/fake_project_2.dart
@@ -1,3 +1,4 @@
+/// Fake project 2 library.
 library fake_project_2;
 
 export 'src/exception.dart';

--- a/packages/coverde_cli/test/src/entities/cov_dir_test.dart
+++ b/packages/coverde_cli/test/src/entities/cov_dir_test.dart
@@ -114,33 +114,41 @@ THEN a positive result should be returned
       ),
     ];
     final tree = CovDir(
-      source: Directory(path.joinAll([
-        'test',
-      ])),
+      source: Directory(
+        path.joinAll([
+          'test',
+        ]),
+      ),
       elements: [
         CovDir(
-          source: Directory(path.joinAll([
-            'test',
-            'dir_1',
-          ])),
+          source: Directory(
+            path.joinAll([
+              'test',
+              'dir_1',
+            ]),
+          ),
           elements: [
             CovFile(
-              source: File(path.joinAll([
-                'test',
-                'dir_1',
-                'file_1.1.ext',
-              ])),
+              source: File(
+                path.joinAll([
+                  'test',
+                  'dir_1',
+                  'file_1.1.ext',
+                ]),
+              ),
               raw: '',
               covLines: [
                 CovLine(lineNumber: 1, hitsNumber: 1, checksum: null),
               ],
             ),
             CovFile(
-              source: File(path.joinAll([
-                'test',
-                'dir_1',
-                'file_1.2.ext',
-              ])),
+              source: File(
+                path.joinAll([
+                  'test',
+                  'dir_1',
+                  'file_1.2.ext',
+                ]),
+              ),
               raw: '',
               covLines: [
                 CovLine(lineNumber: 1, hitsNumber: 1, checksum: null),
@@ -149,33 +157,39 @@ THEN a positive result should be returned
           ],
         ),
         CovDir(
-          source: Directory(path.joinAll([
-            'test',
-            'dir_2',
-            'dir_2_1',
-            'dir_2_1_1',
-          ])),
+          source: Directory(
+            path.joinAll([
+              'test',
+              'dir_2',
+              'dir_2_1',
+              'dir_2_1_1',
+            ]),
+          ),
           elements: [
             CovDir(
-              source: Directory(path.joinAll([
-                'test',
-                'dir_2',
-                'dir_2_1',
-                'dir_2_1_1',
-                'dir_2_1_1_1',
-                'dir_2_1_1_1_1',
-              ])),
+              source: Directory(
+                path.joinAll([
+                  'test',
+                  'dir_2',
+                  'dir_2_1',
+                  'dir_2_1_1',
+                  'dir_2_1_1_1',
+                  'dir_2_1_1_1_1',
+                ]),
+              ),
               elements: [
                 CovFile(
-                  source: File(path.joinAll([
-                    'test',
-                    'dir_2',
-                    'dir_2_1',
-                    'dir_2_1_1',
-                    'dir_2_1_1_1',
-                    'dir_2_1_1_1_1',
-                    'file_2_1_1_1_1.1.ext',
-                  ])),
+                  source: File(
+                    path.joinAll([
+                      'test',
+                      'dir_2',
+                      'dir_2_1',
+                      'dir_2_1_1',
+                      'dir_2_1_1_1',
+                      'dir_2_1_1_1_1',
+                      'file_2_1_1_1_1.1.ext',
+                    ]),
+                  ),
                   raw: '',
                   covLines: [
                     CovLine(lineNumber: 1, hitsNumber: 1, checksum: null),
@@ -184,13 +198,15 @@ THEN a positive result should be returned
               ],
             ),
             CovFile(
-              source: File(path.joinAll([
-                'test',
-                'dir_2',
-                'dir_2_1',
-                'dir_2_1_1',
-                'file_2_1_1.1.ext',
-              ])),
+              source: File(
+                path.joinAll([
+                  'test',
+                  'dir_2',
+                  'dir_2_1',
+                  'dir_2_1_1',
+                  'file_2_1_1.1.ext',
+                ]),
+              ),
               raw: '',
               covLines: [
                 CovLine(lineNumber: 1, hitsNumber: 1, checksum: null),
@@ -331,7 +347,7 @@ Node: ${path.joinAll([
         final result = tree.toString();
 
         // ASSERT
-        final splitter = const LineSplitter();
+        const splitter = LineSplitter();
         expect(
           splitter.convert(result).map((line) => line.trim()),
           splitter.convert(expectedTreeString).map((line) => line.trim()),

--- a/packages/coverde_cli/test/src/utils/command_test.dart
+++ b/packages/coverde_cli/test/src/utils/command_test.dart
@@ -26,7 +26,7 @@ void main() {
 GIVEN a command''',
     () {
       late CommandRunner<void> cmdRunner;
-      late Command cmd;
+      late Command<void> cmd;
 
       // ARRANGE
       setUp(

--- a/packages/package_assets_generator/analysis_options.yaml
+++ b/packages/package_assets_generator/analysis_options.yaml
@@ -1,4 +1,5 @@
-include: package:very_good_analysis/analysis_options.5.0.0.yaml
+include: package:very_good_analysis/analysis_options.yaml
+
 linter:
   rules:
     public_member_api_docs: false

--- a/packages/package_data_generator/analysis_options.yaml
+++ b/packages/package_data_generator/analysis_options.yaml
@@ -1,4 +1,5 @@
-include: package:very_good_analysis/analysis_options.5.0.0.yaml
+include: package:very_good_analysis/analysis_options.yaml
+
 linter:
   rules:
     public_member_api_docs: false

--- a/packages/pub_score_checker/analysis_options.yaml
+++ b/packages/pub_score_checker/analysis_options.yaml
@@ -1,4 +1,5 @@
-include: package:very_good_analysis/analysis_options.5.0.0.yaml
+include: package:very_good_analysis/analysis_options.yaml
+
 linter:
   rules:
     public_member_api_docs: false


### PR DESCRIPTION
## Details

- Always use the latest version of the lint rules provided by the 3rd-party package.
- Solve silently ignored lints.