### PR TITLE
test(coverde-cli): relax E2E tests timeouts

### DIFF
--- a/packages/coverde_cli/e2e/dart_test.yaml
+++ b/packages/coverde_cli/e2e/dart_test.yaml
@@ -1,9 +1,7 @@
-on_os:
-  windows:
-    timeout: 2x
-
 reporter: compact
 
 tags:
   e2e:
     skip: Should be run manually
+
+timeout: 5m


### PR DESCRIPTION
## Details

Use loose timeouts for E2E tests.