### PR TITLE
test(coverde-cli): temporarily skip failing E2E tests on Windows

### DIFF
--- a/packages/coverde_cli/e2e/test/commands/optimize_tests/flutter_golden_test/case_test.dart
+++ b/packages/coverde_cli/e2e/test/commands/optimize_tests/flutter_golden_test/case_test.dart
@@ -16,7 +16,7 @@ void main() {
         projectDirName: 'flutter_project',
         testCommand: 'flutter test --reporter compact',
       ),
-      if (Platform.isWindows)
+      if (!Platform.isWindows)
         // `--platform chrome` fails on Windows
         // Possibly related to https://github.com/flutter/flutter/issues/171436
         (


### PR DESCRIPTION
## Details

Some E2E tests fail on Windows (possibly related to https://github.com/flutter/flutter/issues/171436).
We will temporarily skip them until a reliable method to overcome the issue is found.