### PR TITLE
fix(coverde-cli): use built-in input validation

### DIFF
--- a/packages/coverde_cli/CHANGELOG.md
+++ b/packages/coverde_cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **FIX**: validate regex patterns in `filter` command (#212).
 - **FIX**: validate threshold values in `report` command (#212).
 - **FIX**: proper file deletions (#221).
+- **FIX**: validate log level values in `check` and `value` commands (#222).
 - **FEAT**: use Dart 3.5.0 as minimum SDK version (#114).
 - **FEAT**: add `optimize-tests` command (#115).
 - **FEAT**: add `file-coverage-log-level` option to `check` and `value` commands (#118).

--- a/packages/coverde_cli/lib/src/commands/check/check.dart
+++ b/packages/coverde_cli/lib/src/commands/check/check.dart
@@ -29,6 +29,7 @@ Trace file used for the coverage check.''',
         fileCoverageLogLevelOptionName,
         help: '''
 The log level for the coverage value for each source file listed in the `$inputOptionName` info file.''',
+        allowed: FileCoverageLogLevel.values.map((level) => level.identifier),
         allowedHelp: {
           for (final logLevel in FileCoverageLogLevel.values)
             logLevel.identifier: logLevel.help,
@@ -81,6 +82,8 @@ This parameter indicates the minimum value for the coverage to be accepted.''';
         fileCoverageLogLevelOptionName,
       )!;
       return FileCoverageLogLevel.values.firstWhere(
+        // It is safe to look up the log level by identifier because the allowed
+        // values are validated by the args parser.
         (logLevel) => logLevel.identifier == rawFileCoverageLogLevel,
       );
     }();

--- a/packages/coverde_cli/lib/src/commands/value/value.dart
+++ b/packages/coverde_cli/lib/src/commands/value/value.dart
@@ -32,6 +32,7 @@ Coverage info file to be used for the coverage value computation.''',
         fileCoverageLogLevelFlag,
         help: '''
 The log level for the coverage value for each source file listed in the $_inputHelpValue info file.''',
+        allowed: FileCoverageLogLevel.values.map((level) => level.identifier),
         allowedHelp: {
           for (final logLevel in FileCoverageLogLevel.values)
             logLevel.identifier: logLevel.help,
@@ -77,6 +78,8 @@ Compute the coverage value of the $_inputHelpValue info file.''';
         fileCoverageLogLevelFlag,
       );
       return FileCoverageLogLevel.values.firstWhere(
+        // It is safe to look up the log level by identifier because the allowed
+        // values are validated by the args parser.
         (logLevel) => logLevel.identifier == rawFileCoverageLogLevel,
       );
     }();

--- a/packages/coverde_cli/test/src/commands/check/check_test.dart
+++ b/packages/coverde_cli/test/src/commands/check/check_test.dart
@@ -189,6 +189,44 @@ This parameter indicates the minimum value for the coverage to be accepted.
       );
 
       test(
+        '--${CheckCommand.fileCoverageLogLevelOptionName}=<invalid> '
+        '<min_coverage> '
+        '| fails when --${CheckCommand.fileCoverageLogLevelOptionName} '
+        'is invalid',
+        () async {
+          const invalidLogLevel = 'invalid-log-level';
+          final directory = Directory.systemTemp.createTempSync();
+          final traceFilePath = p.join(directory.path, 'trace.lcov.info');
+          File(traceFilePath).createSync(recursive: true);
+          addTearDown(() => directory.deleteSync(recursive: true));
+          const minCoverage = 50;
+
+          Future<void> action() => cmdRunner.run([
+                checkCmd.name,
+                '--${CheckCommand.inputOptionName}',
+                traceFilePath,
+                '--${CheckCommand.fileCoverageLogLevelOptionName}',
+                invalidLogLevel,
+                '$minCoverage',
+              ]);
+
+          expect(
+            action,
+            throwsA(
+              isA<UsageException>().having(
+                (e) => e.message,
+                'message',
+                contains(
+                  '"invalid-log-level" is not an allowed value '
+                  'for option "--file-coverage-log-level"',
+                ),
+              ),
+            ),
+          );
+        },
+      );
+
+      test(
         '| fails when no minimum expected coverage value',
         () async {
           Future<void> action() => cmdRunner.run([checkCmd.name]);

--- a/packages/coverde_cli/test/src/commands/value/value_test.dart
+++ b/packages/coverde_cli/test/src/commands/value/value_test.dart
@@ -355,6 +355,40 @@ Compute the coverage value of the LCOV_FILE info file.
       );
 
       test(
+        '--${ValueCommand.fileCoverageLogLevelFlag}=<invalid> '
+        '| fails when --${ValueCommand.fileCoverageLogLevelFlag} is invalid',
+        () async {
+          const invalidLogLevel = 'invalid-log-level';
+          final directory = Directory.systemTemp.createTempSync();
+          final traceFilePath = p.join(directory.path, 'trace.lcov.info');
+          File(traceFilePath).createSync(recursive: true);
+          addTearDown(() => directory.deleteSync(recursive: true));
+
+          Future<void> action() => cmdRunner.run([
+                valueCmd.name,
+                '--${ValueCommand.inputOption}',
+                traceFilePath,
+                '--${ValueCommand.fileCoverageLogLevelFlag}',
+                invalidLogLevel,
+              ]);
+
+          expect(
+            action,
+            throwsA(
+              isA<UsageException>().having(
+                (e) => e.message,
+                'message',
+                contains(
+                  '"invalid-log-level" is not an allowed value '
+                  'for option "--file-coverage-log-level"',
+                ),
+              ),
+            ),
+          );
+        },
+      );
+
+      test(
         '--${ValueCommand.inputOption} <absent_trace_file_path>',
         () async {
           final directory = Directory.systemTemp.createTempSync();


### PR DESCRIPTION
## Details

Use built in input validation.