### PR TITLE
test(coverde-cli): Windows E2E test timeouts

### DIFF
--- a/packages/coverde_cli/e2e/dart_test.yaml
+++ b/packages/coverde_cli/e2e/dart_test.yaml
@@ -10,4 +10,4 @@ on_os:
   mac-os:
     timeout: 1m 30s
   windows:
-    timeout: 6m
+    timeout: 10m


### PR DESCRIPTION
## Details

Use special timeout for Windows E2E tests.