### PR TITLE
chore: prepare v04.0

### DIFF
--- a/packages/coverde_cli/CHANGELOG.md
+++ b/packages/coverde_cli/CHANGELOG.md
@@ -1,5 +1,3 @@
-## UNRELEASED
-
 ## 0.4.0
 
 - **BREAKING FEAT**: require analyzer v11+ (#306).

--- a/packages/coverde_cli/CHANGELOG.md
+++ b/packages/coverde_cli/CHANGELOG.md
@@ -1,9 +1,13 @@
 ## UNRELEASED
 
-- **BREAKING FEAT**: full support for analyzer package v8-v10 (#263).
 - **FEAT**: add `transform` command (#276).
 - **FEAT**: support transformation presets in `coverde.yaml` to be used in `transform` command (#278).
 - **CHORE**: deprecate `filter` command in favor of `transform` command (#280).
+
+## 0.4.0
+
+- **BREAKING FEAT**: require analyzer v11+ (#263).
+- **FEAT**: add test sharding support with `--total-shards` and `--shard-index` options to `optimize-tests` command (#303).
 
 ## 0.3.0+1
 

--- a/packages/coverde_cli/CHANGELOG.md
+++ b/packages/coverde_cli/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0
 
-- **BREAKING FEAT**: require analyzer v11+ (#263).
+- **BREAKING FEAT**: require analyzer v11+ (#306).
 - **FEAT**: add test sharding support with `--total-shards` and `--shard-index` options to `optimize-tests` command (#303).
 - **FEAT**: add `transform` command (#276).
 - **FEAT**: support transformation presets in `coverde.yaml` to be used in `transform` command (#278).

--- a/packages/coverde_cli/CHANGELOG.md
+++ b/packages/coverde_cli/CHANGELOG.md
@@ -1,13 +1,12 @@
 ## UNRELEASED
 
-- **FEAT**: add `transform` command (#276).
-- **FEAT**: support transformation presets in `coverde.yaml` to be used in `transform` command (#278).
-- **CHORE**: deprecate `filter` command in favor of `transform` command (#280).
-
 ## 0.4.0
 
 - **BREAKING FEAT**: require analyzer v11+ (#263).
 - **FEAT**: add test sharding support with `--total-shards` and `--shard-index` options to `optimize-tests` command (#303).
+- **FEAT**: add `transform` command (#276).
+- **FEAT**: support transformation presets in `coverde.yaml` to be used in `transform` command (#278).
+- **CHORE**: deprecate `filter` command in favor of `transform` command (#280).
 
 ## 0.3.0+1
 

--- a/packages/coverde_cli/README.md
+++ b/packages/coverde_cli/README.md
@@ -974,7 +974,7 @@ Merge coverage trace files from all packages into a unified trace file:
 coverage.merge:
   description: Merge all packages coverage trace files
   run: >
-    dart run coverde rm
+    dart run coverde remove
     --no-dry-run
     MELOS_ROOT_PATH/coverage/filtered.lcov.info
     &&

--- a/packages/coverde_cli/pubspec.yaml
+++ b/packages/coverde_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: coverde
 description: A CLI for optimizing test execution and manipulating coverage trace files. Optimize tests, validate coverage, filter trace files, and generate HTML reports.
-version: 0.3.0+1
+version: 0.4.0
 homepage: https://github.com/mrverdant13/coverde
 repository: https://github.com/mrverdant13/coverde/tree/main/packages/coverde_cli
 issue_tracker: https://github.com/mrverdant13/coverde/issues


### PR DESCRIPTION
### Details

- Update version to 0.4.0 in pubspec.yaml
- Move unreleased features to 0.4.0 CHANGELOG
- Standardize command names in README
- Clarify analyzer v11+ breaking change
