### PR TITLE
feat(coverde-cli): add wider support for analyzer v12-v14

### DIFF
--- a/packages/coverde_cli/CHANGELOG.md
+++ b/packages/coverde_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+- **FEAT**: add wider support for analyzer package v12-v14.
+
 ## 0.4.0
 
 - **BREAKING FEAT**: require analyzer v11+ (#306).

--- a/packages/coverde_cli/CHANGELOG.md
+++ b/packages/coverde_cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.4.1
 
-- **FEAT**: add wider support for analyzer package v12-v14.
+- **FEAT**: add wider support for analyzer package v12-v14 (#320).
 
 ## 0.4.0
 

--- a/packages/coverde_cli/pubspec.yaml
+++ b/packages/coverde_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: coverde
 description: A CLI for optimizing test execution and manipulating coverage trace files. Optimize tests, validate coverage, filter trace files, and generate HTML reports.
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/mrverdant13/coverde
 repository: https://github.com/mrverdant13/coverde/tree/main/packages/coverde_cli
 issue_tracker: https://github.com/mrverdant13/coverde/issues
@@ -24,7 +24,7 @@ environment:
   sdk: ">=3.5.0 <4.0.0"
 
 dependencies:
-  analyzer: ^11.0.0
+  analyzer: ">=11.0.0 <15.0.0"
   args: ^2.7.0
   code_builder: ^4.11.1
   collection: ^1.19.1


### PR DESCRIPTION
## Summary
- Widen the `analyzer` constraint from `^11.0.0` to `>=11.0.0 <15.0.0` so pub.dev can resolve the latest 14.x and recover the 10 outdated-dependency pub points (150 → 160).
- Bump coverde to 0.4.1. No SDK or `dart_style` bump; pub still pairs analyzer 11 with dart_style 3.1.7, or analyzer 14 with dart_style 3.1.11+.

## Test plan
- [x] `dart analyze --fatal-infos --fatal-warnings` in `packages/coverde_cli`
- [x] `dart pub outdated --no-dev-dependencies --up-to-date --no-dependency-overrides` shows analyzer 14.3.0 as resolvable
- [x] Local pana (`pub_score_checker` local) reports a perfect score
- [x] CI (format, analyze, tests, coverage, local pub score)