### PR TITLE
ci: automate coverde pub.dev releases

### DIFF
--- a/.cspell/ci.allow.txt
+++ b/.cspell/ci.allow.txt
@@ -1,5 +1,7 @@
 # Allowed words for CI files
 codecov
+mapfile
 mrverdant13
+pipefail
 subosito
 webp

--- a/.cspell/docs.allow.txt
+++ b/.cspell/docs.allow.txt
@@ -1,3 +1,4 @@
 # Allowed words for documentation files
 codecov
 Karlo
+runbook

--- a/.github/actions/install-dart-cli/action.yml
+++ b/.github/actions/install-dart-cli/action.yml
@@ -1,0 +1,17 @@
+name: Install Dart CLI package
+description: Run dart install and add the install bin directory to PATH
+inputs:
+  package:
+    description: Package name and optional version constraint (e.g. melos 7.5.1)
+    required: true
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -euo pipefail
+        output="$(dart install ${{ inputs.package }})"
+        echo "$output"
+        installed="$(echo "$output" | grep '^Installed:' | sed 's|^Installed: ||')"
+        bin_dir="$(dirname -- "$installed")"
+        echo "$bin_dir" >> "$GITHUB_PATH"

--- a/.github/actions/install-dart-cli/action.yml
+++ b/.github/actions/install-dart-cli/action.yml
@@ -10,8 +10,29 @@ runs:
     - shell: bash
       run: |
         set -euo pipefail
-        output="$(dart install ${{ inputs.package }})"
-        echo "$output"
-        installed="$(echo "$output" | grep '^Installed:' | sed 's|^Installed: ||')"
-        bin_dir="$(dirname -- "$installed")"
+        dart install ${{ inputs.package }}
+
+        candidates=()
+        if [[ -n "${DART_DATA_HOME:-}" ]]; then
+          candidates+=("${DART_DATA_HOME}/install/bin")
+        fi
+        candidates+=(
+          "${HOME}/Library/Application Support/Dart/install/bin"
+          "${XDG_STATE_HOME:-${HOME}/.local/state}/Dart/install/bin"
+          "${XDG_DATA_HOME:-${HOME}/.local/share}/dart/install/bin"
+        )
+
+        bin_dir=""
+        for dir in "${candidates[@]}"; do
+          if [[ -d "$dir" ]]; then
+            bin_dir="$dir"
+            break
+          fi
+        done
+
+        if [[ -z "$bin_dir" ]]; then
+          echo "::error::dart install bin directory not found after installing ${{ inputs.package }}."
+          exit 1
+        fi
+
         echo "$bin_dir" >> "$GITHUB_PATH"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,19 +32,25 @@ jobs:
         run: melos run format.ci && melos run analyze.ci
 
   release-tools:
-    name: Test release tools
+    name: Test release tools (${{ matrix.package }})
     runs-on: ubuntu-latest
     needs: min-conditions
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - tool/prepare_package_release
+          - tool/wait_for_pub_dev_version
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
       - name: Install dart
         uses: dart-lang/setup-dart@v1
       - name: Install dependencies
-        working-directory: tool
+        working-directory: ${{ matrix.package }}
         run: dart pub get
       - name: Format, analyze, and test
-        working-directory: tool
+        working-directory: ${{ matrix.package }}
         run: >
           dart format --set-exit-if-changed . &&
           dart analyze --fatal-infos --fatal-warnings . &&

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,25 @@ jobs:
       - name: Format and analyze
         run: melos run format.ci && melos run analyze.ci
 
+  release-tools:
+    name: Test release tools
+    runs-on: ubuntu-latest
+    needs: min-conditions
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+      - name: Install dart
+        uses: dart-lang/setup-dart@v1
+      - name: Install dependencies
+        working-directory: tool
+        run: dart pub get
+      - name: Format, analyze, and test
+        working-directory: tool
+        run: >
+          dart format --set-exit-if-changed . &&
+          dart analyze --fatal-infos --fatal-warnings . &&
+          dart test
+
   src-gen:
     name: Ensure up-to-date source generation
     runs-on: ubuntu-latest

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -1,0 +1,110 @@
+# Opens a version-bump release PR for coverde via workflow_dispatch.
+# Runs melos release.prepare, pushes coverde/chore/release-<version>, and opens a PR.
+# Does not publish to pub.dev or create git tags.
+name: Prepare Dart package release
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Package to prepare for release
+        required: true
+        type: choice
+        options:
+          - coverde
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  cancel-in-progress: false
+  group: prepare-release-${{ inputs.package }}
+
+jobs:
+  prepare:
+    name: Prepare release (${{ inputs.package }})
+    runs-on: ubuntu-latest
+    env:
+      PACKAGE_DIR: packages/coverde_cli
+    steps:
+      - name: Check out main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Install Dart
+        uses: dart-lang/setup-dart@v1
+
+      - name: Install melos
+        uses: ./.github/actions/install-dart-cli
+        with:
+          package: melos 7.5.1
+
+      - name: Bootstrap workspace
+        run: melos bs
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump version and changelog
+        run: MELOS_PACKAGES=${{ inputs.package }} melos run release.prepare
+
+      - name: Read release version
+        id: version
+        run: |
+          set -euo pipefail
+          version=$(grep '^version:' "${{ env.PACKAGE_DIR }}/pubspec.yaml" | awk '{print $2}')
+          if [[ -z "$version" ]]; then
+            echo "::error::Could not read version from ${{ env.PACKAGE_DIR }}/pubspec.yaml"
+            exit 1
+          fi
+          echo "value=$version" >> "$GITHUB_OUTPUT"
+          echo "branch=${{ inputs.package }}/chore/release-${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Commit release changes
+        run: |
+          set -euo pipefail
+          package="${{ inputs.package }}"
+          version="${{ steps.version.outputs.value }}"
+
+          git add \
+            "${{ env.PACKAGE_DIR }}/pubspec.yaml" \
+            "${{ env.PACKAGE_DIR }}/CHANGELOG.md" \
+            "${{ env.PACKAGE_DIR }}/lib/src/utils/package_data.dart"
+
+          if git diff --cached --quiet; then
+            echo "::error::No release changes to commit for ${package}."
+            exit 1
+          fi
+
+          git commit -m "chore(${package}): release ${version}"
+
+      - name: Push release branch and open pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          branch="${{ steps.version.outputs.branch }}"
+          version="${{ steps.version.outputs.value }}"
+          package="${{ inputs.package }}"
+
+          git checkout -b "$branch"
+          git push --set-upstream origin "$branch"
+
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "chore(${package}): release ${version}" \
+            --body-file - <<EOF
+          ## Release PR
+
+          Automated version bump for \`${package}\` via the **Prepare Dart package release** workflow.
+
+          - Entry point: \`MELOS_PACKAGES=${package} melos run release.prepare\`
+          - Version bump: \`tool/prepare_package_release.dart\` auto-bump from scoped conventional commits
+          - Changelog: commits scoped \`coverde-cli\` since the latest \`coverde-v<version>\` tag
+          EOF

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -105,6 +105,6 @@ jobs:
           Automated version bump for \`${package}\` via the **Prepare Dart package release** workflow.
 
           - Entry point: \`MELOS_PACKAGES=${package} melos run release.prepare\`
-          - Version bump: \`tool/prepare_package_release.dart\` auto-bump from scoped conventional commits
+          - Version bump: \`tool/prepare_package_release/prepare_package_release.dart\` auto-bump from scoped conventional commits
           - Changelog: commits scoped \`coverde-cli\` since the latest \`coverde-v<version>\` tag
           EOF

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,154 @@
+# Manual pub.dev publish for coverde (OIDC via setup-dart).
+# Trigger via Actions → Publish Dart package.
+#
+# Two-step flow:
+# 1. Merge the release PR — release-tag.yaml pushes coverde-v<version> on the merge commit.
+# 2. Dispatch this workflow on that tag ref with dry_run: false (Use workflow from: Tags).
+#    OIDC auth succeeds on tag refs; publish runs and pub.dev is polled.
+#    On failure, the release tag is deleted so unpublished versions are not permanently tagged.
+#
+# dry_run: true (default) runs release.check only — dispatch from main or a tag ref.
+# dry_run: false publishes via OIDC — must dispatch on the matching release tag ref.
+name: Publish Dart package
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Package to publish
+        required: true
+        type: choice
+        options:
+          - coverde
+      dry_run:
+        description: Pre-publish gate only via release.check (no pub.dev publish)
+        required: true
+        type: boolean
+        default: true
+
+concurrency:
+  cancel-in-progress: false
+  group: publish-${{ inputs.package }}
+
+jobs:
+  check:
+    name: Pre-publish checks (${{ inputs.package }})
+    runs-on: ubuntu-latest
+    env:
+      MELOS_PACKAGES: ${{ inputs.package }}
+      PACKAGE_DIR: packages/coverde_cli
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+      - name: Require release tag ref for live publish
+        if: inputs.dry_run == false
+        env:
+          PACKAGE: ${{ inputs.package }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.ref_type }}" != "tag" ]]; then
+            echo "::error::Live publish must be dispatched on the release tag ref, not a branch. Merge the release PR, wait for the release-tag workflow to finish, then re-run this workflow and select tag \`${PACKAGE}-v<version>\` (Use workflow from: Tags)."
+            exit 1
+          fi
+          version=$(grep '^version:' "${{ env.PACKAGE_DIR }}/pubspec.yaml" | awk '{print $2}')
+          expected_tag="${PACKAGE}-v${version}"
+          if [[ "${{ github.ref_name }}" != "$expected_tag" ]]; then
+            echo "::error::Selected tag ref \`${{ github.ref_name }}\` does not match \`${expected_tag}\` from ${{ env.PACKAGE_DIR }}/pubspec.yaml."
+            exit 1
+          fi
+      - name: Install Dart
+        uses: dart-lang/setup-dart@v1
+      - name: Install melos
+        uses: ./.github/actions/install-dart-cli
+        with:
+          package: melos 7.5.1
+      - name: Bootstrap workspace
+        run: melos bs
+      - name: Run pre-publish gate
+        run: melos run release.check
+
+  publish:
+    name: Publish (${{ inputs.package }})
+    needs: check
+    if: inputs.dry_run == false
+    runs-on: ubuntu-latest
+    environment: pub-dev-publish
+    permissions:
+      contents: write
+      id-token: write
+    env:
+      PACKAGE_DIR: packages/coverde_cli
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Require release tag ref for live publish
+        env:
+          PACKAGE: ${{ inputs.package }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.ref_type }}" != "tag" ]]; then
+            echo "::error::Live publish must be dispatched on the release tag ref, not a branch. Merge the release PR, wait for the release-tag workflow to finish, then re-run this workflow and select tag \`${PACKAGE}-v<version>\` (Use workflow from: Tags)."
+            exit 1
+          fi
+          version=$(grep '^version:' "${{ env.PACKAGE_DIR }}/pubspec.yaml" | awk '{print $2}')
+          expected_tag="${PACKAGE}-v${version}"
+          if [[ "${{ github.ref_name }}" != "$expected_tag" ]]; then
+            echo "::error::Selected tag ref \`${{ github.ref_name }}\` does not match \`${expected_tag}\` from ${{ env.PACKAGE_DIR }}/pubspec.yaml."
+            exit 1
+          fi
+      - name: Install Dart
+        uses: dart-lang/setup-dart@v1
+      - name: Install melos
+        uses: ./.github/actions/install-dart-cli
+        with:
+          package: melos 7.5.1
+      - name: Bootstrap workspace
+        run: melos bs
+      - name: Verify release tag on HEAD
+        env:
+          PACKAGE: ${{ inputs.package }}
+        run: |
+          set -euo pipefail
+          version=$(grep '^version:' "${{ env.PACKAGE_DIR }}/pubspec.yaml" | awk '{print $2}')
+          expected_tag="${PACKAGE}-v${version}"
+          tag_ref="refs/tags/${expected_tag}"
+
+          if ! git rev-parse --verify "$tag_ref" >/dev/null 2>&1; then
+            echo "::error::Release tag ${expected_tag} is missing on this checkout."
+            exit 1
+          fi
+
+          tag_type=$(git cat-file -t "$tag_ref")
+          if [[ "$tag_type" != "tag" ]]; then
+            echo "::error::Release tag ${expected_tag} exists but is not annotated."
+            exit 1
+          fi
+
+          head_commit=$(git rev-parse HEAD)
+          tag_commit=$(git rev-list -n 1 "$expected_tag")
+          if [[ "$tag_commit" != "$head_commit" ]]; then
+            echo "::error::Release tag ${expected_tag} points at ${tag_commit} but HEAD is ${head_commit}."
+            exit 1
+          fi
+
+          echo "Verified annotated tag ${expected_tag} on HEAD."
+      - name: Publish to pub.dev
+        working-directory: packages/coverde_cli
+        run: dart pub publish --force
+      - name: Wait for pub.dev to list the published version
+        working-directory: packages/coverde_cli
+        run: |
+          version=$(grep '^version:' pubspec.yaml | awk '{print $2}')
+          dart run ../../tool/wait_for_pub_dev_version.dart \
+            --package ${{ inputs.package }} \
+            --version "$version"
+      - name: Delete release tag on failure
+        if: failure()
+        env:
+          PACKAGE: ${{ inputs.package }}
+        run: |
+          set -euo pipefail
+          version=$(grep '^version:' "${{ env.PACKAGE_DIR }}/pubspec.yaml" | awk '{print $2}')
+          git push --delete origin "${PACKAGE}-v${version}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -141,7 +141,7 @@ jobs:
         working-directory: packages/coverde_cli
         run: |
           version=$(grep '^version:' pubspec.yaml | awk '{print $2}')
-          dart run ../../tool/wait_for_pub_dev_version.dart \
+          dart run ../../tool/wait_for_pub_dev_version/wait_for_pub_dev_version.dart \
             --package ${{ inputs.package }} \
             --version "$version"
       - name: Delete release tag on failure

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -1,0 +1,147 @@
+# Runs MELOS_PACKAGES-scoped release.check on Dart package release pull requests.
+name: Dart release PR check
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - packages/coverde_cli/pubspec.yaml
+      - packages/coverde_cli/CHANGELOG.md
+
+jobs:
+  parse-title:
+    name: Parse release PR title
+    runs-on: ubuntu-latest
+    outputs:
+      matched: ${{ steps.parse.outputs.matched }}
+      package: ${{ steps.parse.outputs.package }}
+      version: ${{ steps.parse.outputs.version }}
+    steps:
+      - name: Identify package and version from PR title
+        id: parse
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          pattern='^chore\(([^)]+)\): release (.+)$'
+          if [[ "$PR_TITLE" =~ $pattern ]]; then
+            echo "matched=true" >> "$GITHUB_OUTPUT"
+            echo "package=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+            echo "version=${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "matched=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  resolve-package:
+    name: Resolve release package
+    needs: parse-title
+    if: needs.parse-title.outputs.matched == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Install Dart
+        uses: dart-lang/setup-dart@v1
+      - name: Install melos
+        uses: ./.github/actions/install-dart-cli
+        with:
+          package: melos 7.5.1
+      - name: Bootstrap workspace
+        run: melos bs
+      - name: Verify release manifest changes match title
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          TITLE_PACKAGE: ${{ needs.parse-title.outputs.package }}
+          TITLE_VERSION: ${{ needs.parse-title.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          expected_branch="${TITLE_PACKAGE}/chore/release-${TITLE_VERSION}"
+          if [[ "$PR_BRANCH" != "$expected_branch" ]]; then
+            echo "::error::Release PR branch must be named '$expected_branch' (got '$PR_BRANCH')."
+            exit 1
+          fi
+
+          mapfile -t publishable_packages < <(melos list --category=publishable)
+
+          is_publishable() {
+            local candidate="$1"
+            for package in "${publishable_packages[@]}"; do
+              if [[ "$package" == "$candidate" ]]; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          if ! is_publishable "$TITLE_PACKAGE"; then
+            echo "::error::Unknown publishable package '$TITLE_PACKAGE'. Expected one of: ${publishable_packages[*]}"
+            exit 1
+          fi
+
+          declare -A changed_packages=()
+
+          while IFS= read -r file; do
+            if [[ "$file" == packages/coverde_cli/pubspec.yaml || \
+                  "$file" == packages/coverde_cli/CHANGELOG.md ]]; then
+              if is_publishable "coverde"; then
+                changed_packages["coverde"]=1
+              fi
+            fi
+          done < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+
+          if [[ "${#changed_packages[@]}" -eq 0 ]]; then
+            echo "::error::No release manifest changes detected in this pull request."
+            exit 1
+          fi
+
+          if [[ "${#changed_packages[@]}" -gt 1 ]]; then
+            packages_list="$(printf '%s, ' "${!changed_packages[@]}")"
+            packages_list="${packages_list%, }"
+            echo "::error::Release PRs must change exactly one publishable package. Multiple packages were modified: $packages_list. Split into separate release PRs — see CONTRIBUTING.md."
+            exit 1
+          fi
+
+          changed_package="${!changed_packages[@]}"
+
+          if [[ "$changed_package" != "$TITLE_PACKAGE" ]]; then
+            echo "::error::Release manifest changes target $changed_package but the PR title indicates $TITLE_PACKAGE."
+            exit 1
+          fi
+
+  release-check:
+    name: release.check (${{ needs.parse-title.outputs.package }} ${{ needs.parse-title.outputs.version }})
+    needs:
+      - parse-title
+      - resolve-package
+    if: needs.parse-title.outputs.matched == 'true'
+    runs-on: ubuntu-latest
+    env:
+      MELOS_PACKAGES: ${{ needs.parse-title.outputs.package }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+      - name: Install Dart
+        uses: dart-lang/setup-dart@v1
+      - name: Install melos
+        uses: ./.github/actions/install-dart-cli
+        with:
+          package: melos 7.5.1
+      - name: Bootstrap workspace
+        run: melos bs
+      - name: Run pre-publish gate
+        run: melos run release.check
+      - name: Set step summary
+        if: always()
+        run: |
+          report="packages/coverde_cli/.dart_tool/local_pub_score.md"
+          if [[ -f "$report" ]]; then
+            echo "### ${MELOS_PACKAGES}" >> "$GITHUB_STEP_SUMMARY"
+            cat "$report" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -1,0 +1,153 @@
+# Creates annotated release tags when Dart package release PRs merge to main.
+# Live pub.dev publish is a separate manual workflow_dispatch on the tag ref (OIDC).
+# Tags pushed from this workflow cannot trigger the publish workflow via push:tags.
+name: Release tag on merge
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Package to recreate release tag for on main
+        required: true
+        type: choice
+        options:
+          - coverde
+
+permissions:
+  contents: write
+
+jobs:
+  resolve:
+    name: Resolve release target
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.resolve.outputs.should_run }}
+      package: ${{ steps.resolve.outputs.package }}
+      version: ${{ steps.resolve.outputs.version }}
+      checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
+    steps:
+      - name: Resolve release target
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          DISPATCH_PACKAGE: ${{ inputs.package }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            if [[ "$PR_MERGED" != "true" ]]; then
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            release_title_re='^chore\(([^)]+)\): release (.+)$'
+            if [[ ! "$PR_TITLE" =~ $release_title_re ]]; then
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+
+            package="${BASH_REMATCH[1]}"
+            version="${BASH_REMATCH[2]}"
+            expected_branch="${package}/chore/release-${version}"
+
+            if [[ "$PR_BRANCH" != "$expected_branch" ]]; then
+              echo "::error::Release PR branch must be named '$expected_branch' (got '$PR_BRANCH')."
+              exit 1
+            fi
+
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "package=$package" >> "$GITHUB_OUTPUT"
+            echo "version=$version" >> "$GITHUB_OUTPUT"
+            echo "checkout_ref=$MERGE_COMMIT_SHA" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+          echo "package=$DISPATCH_PACKAGE" >> "$GITHUB_OUTPUT"
+          echo "checkout_ref=main" >> "$GITHUB_OUTPUT"
+
+  tag:
+    name: Tag release (${{ needs.resolve.outputs.package }})
+    needs: resolve
+    if: needs.resolve.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      cancel-in-progress: false
+      group: release-tag-${{ needs.resolve.outputs.package }}
+    env:
+      PACKAGE_DIR: packages/coverde_cli
+    steps:
+      - name: Check out release commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve.outputs.checkout_ref }}
+          fetch-depth: 0
+
+      - name: Validate release version
+        id: version
+        env:
+          PACKAGE: ${{ needs.resolve.outputs.package }}
+          EXPECTED_VERSION: ${{ needs.resolve.outputs.version }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+
+          pubspec_version=$(grep '^version:' "${{ env.PACKAGE_DIR }}/pubspec.yaml" | awk '{print $2}')
+          if [[ -z "$pubspec_version" ]]; then
+            echo "::error::Could not read version from ${{ env.PACKAGE_DIR }}/pubspec.yaml"
+            exit 1
+          fi
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "value=$pubspec_version" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$pubspec_version" != "$EXPECTED_VERSION" ]]; then
+            echo "::error::${{ env.PACKAGE_DIR }}/pubspec.yaml version is $pubspec_version but the release PR title indicates $EXPECTED_VERSION."
+            exit 1
+          fi
+
+          echo "value=$pubspec_version" >> "$GITHUB_OUTPUT"
+
+      - name: Skip when release tag already exists
+        id: skip
+        env:
+          PACKAGE: ${{ needs.resolve.outputs.package }}
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          set -euo pipefail
+          tag_name="${PACKAGE}-v${VERSION}"
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${tag_name}" >/dev/null 2>&1; then
+            echo "Tag ${tag_name} already exists on origin; skipping tag creation."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure git author
+        if: steps.skip.outputs.skip != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and push annotated release tag
+        if: steps.skip.outputs.skip != 'true'
+        env:
+          PACKAGE: ${{ needs.resolve.outputs.package }}
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          set -euo pipefail
+          tag_name="${PACKAGE}-v${VERSION}"
+          git tag -a "$tag_name" -m "${PACKAGE} ${VERSION}"
+          git push origin "$tag_name"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,13 @@ If you'd like to report a bug or join in the development of `coverde`, then here
   - [Coding Guidelines](#coding-guidelines)
     - [Pre-requisites](#pre-requisites)
     - [Pull Requests](#pull-requests)
+  - [Releasing `coverde`](#releasing-coverde)
+    - [pub.dev automated publishing setup](#pubdev-automated-publishing-setup)
+    - [CI release workflows](#ci-release-workflows)
+    - [Release runbook](#release-runbook)
+    - [How CI scopes `release.check`](#how-ci-scopes-releasecheck)
+    - [Prepare tool flags](#prepare-tool-flags)
+    - [Release tagging](#release-tagging)
 
 ## Reporting bugs and opening issues
 
@@ -50,6 +57,113 @@ For commits, this repo follows the [Conventional Commits Specification][conventi
 - PRs should keep a resultant pub score with the maximum tolerance defined in the [`melos` configuration of the `pubspec.yaml`][_docs_pubspec_file].
 
 To easily check if these conditions are satisfied, you can use a collection of melos scripts defined in the same [`melos` configuration][_docs_pubspec_file].
+
+Keep PRs scoped to **one package** when possible. Repo-root wiring (workflows, Melos scripts, this guide) should not mix with package source changes.
+
+Commit scopes used by release changelog generation:
+
+- `coverde-cli` — the publishable `coverde` package in `packages/coverde_cli/`
+- Tool packages use a `t-` prefix (for example `t-readmes-resolver`)
+
+## Releasing `coverde`
+
+The publishable package is **`coverde`** (directory [`packages/coverde_cli/`](packages/coverde_cli/)). Version is declared in `pubspec.yaml` and generated into `lib/src/utils/package_data.dart` as `packageVersion`.
+
+**Release invariants:**
+
+- **One package per release PR** — a release touches only `packages/coverde_cli/pubspec.yaml`, `CHANGELOG.md`, and `lib/src/utils/package_data.dart`.
+- **Tag before OIDC publish** — merging a release PR pushes annotated tag `coverde-v<version>` on the merge commit via [Release tag on merge](.github/workflows/release-tag.yaml).
+- **Poll after publish** — the publish workflow polls pub.dev until the version appears.
+- **No permanent tag for failed publishes** — if publish or the pub.dev poll fails, the publish workflow deletes the release tag.
+- **Explicit publish opt-in** — live pub.dev publishes require a manual **Publish Dart package** dispatch with `dry_run: false` on the matching tag ref.
+
+### pub.dev automated publishing setup
+
+Live pub.dev publishes use **GitHub OIDC** via [`dart-lang/setup-dart@v1`](https://github.com/dart-lang/setup-dart) — no long-lived publish tokens. Complete this one-time setup on [pub.dev](https://pub.dev/packages/coverde) → **Admin** → **Automated publishing**. See [Dart automated publishing](https://dart.dev/tools/pub/automated-publishing#configuring-automated-publishing-from-github-actions-on-pubdev).
+
+| Package   | pub.dev package | Tag pattern on pub.dev |
+| --------- | --------------- | ---------------------- |
+| `coverde` | `coverde`       | `coverde-v{{version}}` |
+
+1. Enable **Publishing from GitHub Actions**.
+2. Set **Repository** to `mrverdant13/coverde`.
+3. Set **Tag pattern** to `coverde-v{{version}}` (for example `coverde-v0.4.1`), **not** `v{{version}}`.
+4. Enable **Publishing from `workflow_dispatch` events**.
+5. Optionally enable **Require GitHub Actions environment** and name it `pub-dev-publish`.
+
+Create the GitHub environment `pub-dev-publish` with required reviewers. After the first successful OIDC publish, remove any leftover `PUB_CREDENTIALS` secret.
+
+**Baseline tag:** `main` is `0.4.1` but the latest historical tag is `coverde-v0.4.0`. Create annotated tag `coverde-v0.4.1` on the `0.4.1` commit before the first automated prepare, or the safety gate fails (`pubspecAheadOfTag`).
+
+### CI release workflows
+
+Regular [Dart CI](.github/workflows/ci.yaml) does not run `release.check` or publish. Release automation uses four dedicated workflows:
+
+| Workflow | Trigger | Purpose |
+| -------- | ------- | ------- |
+| **[Prepare Dart package release](.github/workflows/prepare-release.yaml)** | `workflow_dispatch` — choose `coverde` | Runs scoped `release.prepare`, pushes `coverde/chore/release-<version>`, and opens a release PR |
+| **[Dart release PR check](.github/workflows/release-pr.yaml)** | Pull request to `main` when release manifests change | Runs `MELOS_PACKAGES`-scoped `release.check` when the PR title and branch match |
+| **[Release tag on merge](.github/workflows/release-tag.yaml)** | Merged release PR to `main`; optional `workflow_dispatch` | Creates annotated tag `coverde-v<version>` on the merge commit |
+| **[Publish Dart package](.github/workflows/publish.yaml)** | `workflow_dispatch` — choose package and `dry_run` | Pre-publish gate (`dry_run: true`) or OIDC live publish (`dry_run: false` on the matching tag ref) |
+
+### Release runbook
+
+1. **Prepare commits on `main`.** Merged work should use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) with scope `coverde-cli` so the prepare tool can include them.
+2. **Prepare the release.** Run **Actions → Prepare Dart package release** and choose `coverde`. The workflow runs `MELOS_PACKAGES=coverde melos run release.prepare`, which invokes [`tool/prepare_package_release.dart`](tool/prepare_package_release.dart) in auto-bump mode, prepends a changelog from `coverde-cli`-scoped commits since the latest `coverde-v*` tag, regenerates `package_data.dart`, then commits those files. It pushes `coverde/chore/release-<version>` and opens a PR titled `chore(coverde): release <version>`.
+   - **Local writes:** `MELOS_PACKAGES=coverde melos run release.prepare`
+   - **Local preview (dry-run):**
+     ```bash
+     dart run tool/prepare_package_release.dart \
+       --cwd packages/coverde_cli \
+       --tag-format '{name}-v{version}' \
+       --scopes coverde-cli \
+       --commit-types feat,fix,docs,refactor,perf,test,build,chore
+     ```
+3. **Review the release PR.** Confirm version, changelog, and generated `packageVersion`.
+4. **Wait for release PR CI.** [Dart release PR check](.github/workflows/release-pr.yaml) runs scoped `release.check`.
+5. **Merge the release PR** into `main`. [Release tag on merge](.github/workflows/release-tag.yaml) pushes `coverde-v<version>`.
+6. **Publish to pub.dev.** Run **Actions → Publish Dart package**, choose **Use workflow from: Tags**, select `coverde-v<version>`, set `dry_run: false`, and approve `pub-dev-publish`. The workflow publishes via OIDC and polls pub.dev ([`tool/wait_for_pub_dev_version.dart`](tool/wait_for_pub_dev_version.dart)).
+   - **Failure recovery:** If publish or the poll fails, the workflow deletes the tag. Recreate it with **Release tag on merge** (`workflow_dispatch` on `main`), then dispatch publish again.
+   - **Pre-publish gate:** Dispatch the same workflow with `dry_run: true` to run `release.check` only.
+
+Auto-bump rules (stable versions):
+
+- `feat` → minor (`0.4.1` → `0.5.0`)
+- `fix` → patch (`0.4.1` → `0.4.2`)
+- other allowed types only → build (`0.4.1` → `0.4.1+1`)
+- breaking `feat` in `0.x` → minor; once `major >= 1`, breaking `feat` → major
+
+### How CI scopes `release.check`
+
+`release.check` is a composite Melos script. CI sets `MELOS_PACKAGES=coverde` so nested Melos steps scope to that package. Passing `--scope` on the outer command would **not** propagate.
+
+`format.ci` and `analyze.ci` still validate the **whole workspace**. Only Melos `exec` / filtered steps honor `MELOS_PACKAGES`.
+
+### Prepare tool flags
+
+| Flag | Purpose |
+| --- | --- |
+| `--cwd` | Package root (`packages/coverde_cli`). |
+| `--tag-format` | Embedded value: `'{name}-v{version}'` (for example `coverde-v0.4.1`). |
+| `--scopes` | Embedded value: `coverde-cli`. |
+| `--commit-types` | Embedded value: `feat,fix,docs,refactor,perf,test,build,chore`. |
+| *(no `--bump`)* | Auto-bump from scoped commits. |
+| `--bump patch\|minor\|major\|build` | Explicit segment bump (direct tool invocation). |
+| `--version <semver>` | Exact target version. Mutually exclusive with `--bump`. |
+| `--allow-unsafe-bump` | Skip the tag/pubspec equality safety gate. |
+| `--apply` | Write `pubspec.yaml` and prepend `CHANGELOG.md`. Always passed by `release.prepare`. |
+
+### Release tagging
+
+Format:
+
+```
+coverde-v<version>
+```
+
+Examples: `coverde-v0.4.1`, `coverde-v0.4.1+1`. No extra `v` prefix beyond the historical `coverde-v` style.
+
+When a tag is missing on `main`, run **Actions → Release tag on merge** on branch `main` and choose `coverde`.
 
 [_docs_pubspec_file]: https://github.com/mrverdant13/coverde/blob/main/pubspec.yaml
 [conventional_commit_specification_link]: https://www.conventionalcommits.org/en/v1.0.0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,11 +109,11 @@ Regular [Dart CI](.github/workflows/ci.yaml) does not run `release.check` or pub
 ### Release runbook
 
 1. **Prepare commits on `main`.** Merged work should use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) with scope `coverde-cli` so the prepare tool can include them.
-2. **Prepare the release.** Run **Actions → Prepare Dart package release** and choose `coverde`. The workflow runs `MELOS_PACKAGES=coverde melos run release.prepare`, which invokes [`tool/prepare_package_release.dart`](tool/prepare_package_release.dart) in auto-bump mode, prepends a changelog from `coverde-cli`-scoped commits since the latest `coverde-v*` tag, regenerates `package_data.dart`, then commits those files. It pushes `coverde/chore/release-<version>` and opens a PR titled `chore(coverde): release <version>`.
+2. **Prepare the release.** Run **Actions → Prepare Dart package release** and choose `coverde`. The workflow runs `MELOS_PACKAGES=coverde melos run release.prepare`, which invokes [`tool/prepare_package_release/prepare_package_release.dart`](tool/prepare_package_release/prepare_package_release.dart) in auto-bump mode, prepends a changelog from `coverde-cli`-scoped commits since the latest `coverde-v*` tag, regenerates `package_data.dart`, then commits those files. It pushes `coverde/chore/release-<version>` and opens a PR titled `chore(coverde): release <version>`.
    - **Local writes:** `MELOS_PACKAGES=coverde melos run release.prepare`
    - **Local preview (dry-run):**
      ```bash
-     dart run tool/prepare_package_release.dart \
+     dart run tool/prepare_package_release/prepare_package_release.dart \
        --cwd packages/coverde_cli \
        --tag-format '{name}-v{version}' \
        --scopes coverde-cli \
@@ -122,7 +122,7 @@ Regular [Dart CI](.github/workflows/ci.yaml) does not run `release.check` or pub
 3. **Review the release PR.** Confirm version, changelog, and generated `packageVersion`.
 4. **Wait for release PR CI.** [Dart release PR check](.github/workflows/release-pr.yaml) runs scoped `release.check`.
 5. **Merge the release PR** into `main`. [Release tag on merge](.github/workflows/release-tag.yaml) pushes `coverde-v<version>`.
-6. **Publish to pub.dev.** Run **Actions → Publish Dart package**, choose **Use workflow from: Tags**, select `coverde-v<version>`, set `dry_run: false`, and approve `pub-dev-publish`. The workflow publishes via OIDC and polls pub.dev ([`tool/wait_for_pub_dev_version.dart`](tool/wait_for_pub_dev_version.dart)).
+6. **Publish to pub.dev.** Run **Actions → Publish Dart package**, choose **Use workflow from: Tags**, select `coverde-v<version>`, set `dry_run: false`, and approve `pub-dev-publish`. The workflow publishes via OIDC and polls pub.dev ([`tool/wait_for_pub_dev_version/wait_for_pub_dev_version.dart`](tool/wait_for_pub_dev_version/wait_for_pub_dev_version.dart)).
    - **Failure recovery:** If publish or the poll fails, the workflow deletes the tag. Recreate it with **Release tag on merge** (`workflow_dispatch` on `main`), then dispatch publish again.
    - **Pre-publish gate:** Dispatch the same workflow with `dry_run: true` to run `release.check` only.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,10 @@ Keep PRs scoped to **one package** when possible. Repo-root wiring (workflows, M
 Commit scopes used by release changelog generation:
 
 - `coverde-cli` — the publishable `coverde` package in `packages/coverde_cli/`
-- Tool packages use a `t-` prefix (for example `t-readmes-resolver`)
+- Tool packages use a `t-` prefix:
+  - `t-readmes-resolver`
+  - `t-prepare-package-release`
+  - `t-wait-for-pub-dev-version`
 
 ## Releasing `coverde`
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -193,7 +193,7 @@ melos:
         Bump version and changelog for a single package release. Set
         MELOS_PACKAGES=<package> to scope to one package.
       run: >
-        dart run MELOS_ROOT_PATH/tool/prepare_package_release.dart
+        dart run MELOS_ROOT_PATH/tool/prepare_package_release/prepare_package_release.dart
         --cwd "MELOS_PACKAGE_PATH"
         --tag-format '{name}-v{version}'
         --scopes coverde-cli

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,8 @@ melos:
       - ./tools/**
     e2e:
       - "**/e2e"
+    publishable:
+      - packages/coverde_cli
 
   command:
     bootstrap:
@@ -161,7 +163,8 @@ melos:
       exec:
         concurrency: 1
       packageFilters:
-        scope: coverde
+        category:
+          - publishable
     pub-score.local:
       description: Check pub score for a selected package.
       run: >
@@ -171,7 +174,37 @@ melos:
       exec:
         concurrency: 1
       packageFilters:
-        scope: coverde
+        category:
+          - publishable
+
+    release.check:
+      description: >
+        Pre-publish gate. Set MELOS_PACKAGES=<package> to scope Melos-driven
+        steps to one package; omit for all publishable packages.
+      steps:
+        - format.ci
+        - analyze.ci
+        - test.ci
+        - pub-score.local
+        - melos publish --dry-run --category publishable --yes
+
+    release.prepare:
+      description: >
+        Bump version and changelog for a single package release. Set
+        MELOS_PACKAGES=<package> to scope to one package.
+      run: >
+        dart run MELOS_ROOT_PATH/tool/prepare_package_release.dart
+        --cwd "MELOS_PACKAGE_PATH"
+        --tag-format '{name}-v{version}'
+        --scopes coverde-cli
+        --commit-types feat,fix,docs,refactor,perf,test,build,chore
+        --apply
+        &&
+        dart run build_runner build --delete-conflicting-outputs
+      exec: {}
+      packageFilters:
+        category:
+          - publishable
 
     # Documentation
     docs.cli:


### PR DESCRIPTION
## Summary
- Add Melos `publishable` category plus `release.prepare` / `release.check` scripts (stable auto-bump, `coverde-v*` tags, `coverde-cli` scopes).
- Add the four Clay-style workflows and `install-dart-cli`; hook a `release-tools` matrix for `tool/prepare_package_release` and `tool/wait_for_pub_dev_version`.
- Document the release runbook and one-time pub.dev / tag setup in CONTRIBUTING.

#322 and #325 are on `main`. #323 (git-ref pin) was closed as unused under workspace resolution.

## Test plan
- [x] CI `release-tools` matrix passes for both tool packages.
- [x] Melos: `melos list --category=publishable` prints `coverde`.
- [x] After merge, create GitHub env `pub-dev-publish`, configure pub.dev OIDC (`coverde-v{{version}}`), and add annotated tag `coverde-v0.4.1` on the current `0.4.1` commit.