### PR TITLE
feat(t-wait-for-pub-dev-version): add pub.dev wait tool

### DIFF
--- a/tool/wait_for_pub_dev_version/.gitignore
+++ b/tool/wait_for_pub_dev_version/.gitignore
@@ -1,0 +1,7 @@
+# See https://www.dartlang.org/guides/libraries/private-files
+
+# Files and directories created by pub
+.dart_tool/
+.packages
+build/
+pubspec.lock

--- a/tool/wait_for_pub_dev_version/analysis_options.yaml
+++ b/tool/wait_for_pub_dev_version/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:very_good_analysis/analysis_options.yaml
+
+linter:
+  rules:
+    public_member_api_docs: false

--- a/tool/wait_for_pub_dev_version/package_configs.dart
+++ b/tool/wait_for_pub_dev_version/package_configs.dart
@@ -1,0 +1,18 @@
+/// Hardcoded package metadata for release tooling that has not yet adopted
+/// `--cwd`. Used by `wait_for_pub_dev_version.dart`.
+const packageConfigs = <String, PackageConfig>{
+  'coverde': PackageConfig(
+    packagePath: 'packages/coverde_cli',
+    versionConstName: 'packageVersion',
+  ),
+};
+
+class PackageConfig {
+  const PackageConfig({
+    required this.packagePath,
+    required this.versionConstName,
+  });
+
+  final String packagePath;
+  final String versionConstName;
+}

--- a/tool/wait_for_pub_dev_version/pubspec.yaml
+++ b/tool/wait_for_pub_dev_version/pubspec.yaml
@@ -1,0 +1,9 @@
+name: wait_for_pub_dev_version
+publish_to: none
+
+environment:
+  sdk: ">=3.5.0 <4.0.0"
+
+dev_dependencies:
+  test: ^1.25.0
+  very_good_analysis: ^10.2.0

--- a/tool/wait_for_pub_dev_version/test/fixtures/coverde_api.json
+++ b/tool/wait_for_pub_dev_version/test/fixtures/coverde_api.json
@@ -1,0 +1,12 @@
+{
+  "name": "coverde",
+  "latest": {
+    "version": "0.4.1"
+  },
+  "versions": [
+    {
+      "version": "0.4.1",
+      "published": "2026-05-02T00:00:00.000000Z"
+    }
+  ]
+}

--- a/tool/wait_for_pub_dev_version/test/wait_for_pub_dev_version_test.dart
+++ b/tool/wait_for_pub_dev_version/test/wait_for_pub_dev_version_test.dart
@@ -1,0 +1,128 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+import '../wait_for_pub_dev_version.dart';
+
+void main() {
+  group('versionListedInPubDevResponse', () {
+    late String coverdeFixture;
+
+    setUp(() {
+      coverdeFixture = File(
+        'test/fixtures/coverde_api.json',
+      ).readAsStringSync();
+    });
+
+    test('returns true when the version is listed', () {
+      expect(
+        versionListedInPubDevResponse(coverdeFixture, '0.4.1'),
+        isTrue,
+      );
+    });
+
+    test('returns false when the version is absent', () {
+      expect(
+        versionListedInPubDevResponse(coverdeFixture, '9.9.9'),
+        isFalse,
+      );
+    });
+
+    test('returns false when versions is missing', () {
+      expect(
+        versionListedInPubDevResponse('{"name":"coverde"}', '0.4.1'),
+        isFalse,
+      );
+    });
+
+    test('returns false for invalid JSON', () {
+      expect(
+        versionListedInPubDevResponse('not-json', '0.4.1'),
+        isFalse,
+      );
+    });
+  });
+
+  group('waitForPubDevVersion', () {
+    test('returns 0 when the version is found on the first attempt', () async {
+      final exitCode = await waitForPubDevVersion(
+        packageName: 'coverde',
+        version: '0.4.1',
+        timeout: const Duration(seconds: 1),
+        interval: const Duration(milliseconds: 10),
+        fetchPackage: (_) async => File(
+          'test/fixtures/coverde_api.json',
+        ).readAsStringSync(),
+      );
+
+      expect(exitCode, 0);
+    });
+
+    test('returns 1 when the version is never listed before timeout', () async {
+      var now = DateTime.utc(2026, 1, 1, 12);
+
+      final exitCode = await waitForPubDevVersion(
+        packageName: 'coverde',
+        version: '9.9.9',
+        timeout: const Duration(seconds: 1),
+        interval: const Duration(milliseconds: 200),
+        now: () => now,
+        sleep: (_) async {
+          now = now.add(const Duration(milliseconds: 500));
+        },
+        fetchPackage: (_) async => File(
+          'test/fixtures/coverde_api.json',
+        ).readAsStringSync(),
+      );
+
+      expect(exitCode, 1);
+    });
+
+    test('returns 1 immediately when the package is missing on pub.dev',
+        () async {
+      final exitCode = await waitForPubDevVersion(
+        packageName: 'coverde',
+        version: '0.4.1',
+        timeout: const Duration(seconds: 5),
+        interval: const Duration(milliseconds: 10),
+        fetchPackage: (_) async => throw PubDevPackageNotFoundException(
+          'Package not found on pub.dev: coverde',
+        ),
+      );
+
+      expect(exitCode, 1);
+    });
+
+    test('returns 1 when fetch returns invalid JSON before timeout', () async {
+      var now = DateTime.utc(2026, 1, 1, 12);
+
+      final exitCode = await waitForPubDevVersion(
+        packageName: 'coverde',
+        version: '0.4.1',
+        timeout: const Duration(seconds: 1),
+        interval: const Duration(milliseconds: 200),
+        now: () => now,
+        sleep: (_) async {
+          now = now.add(const Duration(milliseconds: 500));
+        },
+        fetchPackage: (_) async => 'not-json',
+      );
+
+      expect(exitCode, 1);
+    });
+
+    test('returns 1 when fetch fails after retries', () async {
+      final exitCode = await waitForPubDevVersion(
+        packageName: 'coverde',
+        version: '0.4.1',
+        timeout: const Duration(seconds: 5),
+        interval: const Duration(milliseconds: 10),
+        fetchPackage: (_) async => throw PubDevFetchException(
+          'pub.dev API returned HTTP 503 for coverde after 3 attempts.',
+        ),
+      );
+
+      expect(exitCode, 1);
+    });
+  });
+}

--- a/tool/wait_for_pub_dev_version/wait_for_pub_dev_version.dart
+++ b/tool/wait_for_pub_dev_version/wait_for_pub_dev_version.dart
@@ -1,0 +1,406 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package_configs.dart';
+
+const defaultPollTimeout = Duration(minutes: 10);
+const defaultPollInterval = Duration(seconds: 20);
+const pubDevPackageApiBase = 'https://pub.dev/api/packages';
+const maxFetchAttempts = 3;
+const pubDevRequestTimeout = Duration(seconds: 30);
+
+void main(List<String> arguments) async {
+  final options = _readOptions(arguments);
+  if (options == null) {
+    _printUsage();
+    exit(64);
+  }
+
+  if (packageConfigs[options.packageName] == null) {
+    stderr
+      ..writeln('Unknown package: ${options.packageName}')
+      ..writeln('Supported packages: ${packageConfigs.keys.join(', ')}');
+    exit(1);
+  }
+
+  final exitCode = await waitForPubDevVersion(
+    packageName: options.packageName,
+    version: options.version,
+    timeout: options.timeout,
+    interval: options.interval,
+    fetchPackage: _fetchPubDevPackage,
+    log: stdout.writeln,
+    errorLog: stderr.writeln,
+  );
+  exit(exitCode);
+}
+
+/// Returns `true` when [responseBody] lists [version] in its `versions` array.
+///
+/// Returns `false` for malformed JSON or unexpected response shapes.
+bool versionListedInPubDevResponse(String responseBody, String version) {
+  final Object? decoded;
+  try {
+    decoded = jsonDecode(responseBody);
+  } on FormatException {
+    return false;
+  }
+
+  if (decoded is! Map) {
+    return false;
+  }
+
+  final versions = decoded['versions'];
+  if (versions is! List) {
+    return false;
+  }
+
+  for (final entry in versions) {
+    if (entry is Map && entry['version'] == version) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/// Polls pub.dev until [version] is listed for [packageName], or [timeout]
+/// elapses.
+///
+/// Returns `0` when the version is found and a non-zero exit code on failure.
+Future<int> waitForPubDevVersion({
+  required String packageName,
+  required String version,
+  required Duration timeout,
+  required Duration interval,
+  required Future<String> Function(String packageName) fetchPackage,
+  void Function(String message)? log,
+  void Function(String message)? errorLog,
+  DateTime Function()? now,
+  Future<void> Function(Duration duration)? sleep,
+}) async {
+  final clock = now ?? DateTime.now;
+  final wait = sleep ?? Future<void>.delayed;
+  final deadline = clock().add(timeout);
+  var attempt = 0;
+
+  while (!clock().isAfter(deadline)) {
+    attempt++;
+    try {
+      final responseBody = await fetchPackage(packageName);
+      if (versionListedInPubDevResponse(responseBody, version)) {
+        log?.call(
+          'Found $packageName $version on pub.dev after $attempt '
+          '${attempt == 1 ? 'attempt' : 'attempts'}.',
+        );
+        return 0;
+      }
+
+      log?.call(
+        'Attempt $attempt: $packageName $version is not listed on pub.dev yet.',
+      );
+    } on PubDevPackageNotFoundException catch (error) {
+      errorLog?.call(error.message);
+      return 1;
+    } on PubDevFetchException catch (error) {
+      errorLog?.call(error.message);
+      return 1;
+    }
+
+    if (clock().add(interval).isAfter(deadline)) {
+      break;
+    }
+
+    await wait(interval);
+  }
+
+  errorLog?.call(
+    'Timed out after ${timeout.inSeconds}s waiting for '
+    '$packageName $version on pub.dev.',
+  );
+  return 1;
+}
+
+Future<String> _fetchPubDevPackage(String packageName) async {
+  final client = HttpClient()
+    ..connectionTimeout = pubDevRequestTimeout
+    ..idleTimeout = pubDevRequestTimeout;
+  try {
+    for (var attempt = 1; attempt <= maxFetchAttempts; attempt++) {
+      try {
+        final responseBody = await _fetchPubDevPackageAttempt(
+          client,
+          packageName,
+        ).timeout(pubDevRequestTimeout);
+
+        return responseBody;
+      } on PubDevPackageNotFoundException {
+        rethrow;
+      } on PubDevFetchException catch (error) {
+        final isLastAttempt = attempt == maxFetchAttempts;
+        if (isLastAttempt) {
+          throw PubDevFetchException(
+            '${error.message} after $maxFetchAttempts attempts.',
+          );
+        }
+
+        await Future<void>.delayed(Duration(seconds: attempt));
+      } on TimeoutException catch (error) {
+        final isLastAttempt = attempt == maxFetchAttempts;
+        if (isLastAttempt) {
+          throw PubDevFetchException(
+            'Timed out fetching pub.dev package metadata for $packageName '
+            'after $maxFetchAttempts attempts: $error',
+          );
+        }
+
+        await Future<void>.delayed(Duration(seconds: attempt));
+      } on Object catch (error) {
+        final isLastAttempt = attempt == maxFetchAttempts;
+        if (isLastAttempt) {
+          throw PubDevFetchException(
+            'Failed to fetch pub.dev package metadata for $packageName '
+            'after $maxFetchAttempts attempts: $error',
+          );
+        }
+
+        await Future<void>.delayed(Duration(seconds: attempt));
+      }
+    }
+
+    throw PubDevFetchException(
+      'Failed to fetch pub.dev package metadata for $packageName.',
+    );
+  } finally {
+    client.close(force: true);
+  }
+}
+
+Future<String> _fetchPubDevPackageAttempt(
+  HttpClient client,
+  String packageName,
+) async {
+  final request = await client.getUrl(
+    Uri.parse('$pubDevPackageApiBase/$packageName'),
+  );
+  final response = await request.close();
+  final responseBody = await response.transform(utf8.decoder).join();
+
+  if (response.statusCode == HttpStatus.notFound) {
+    throw PubDevPackageNotFoundException(
+      'Package not found on pub.dev: $packageName',
+    );
+  }
+
+  if (response.statusCode != HttpStatus.ok) {
+    throw PubDevFetchException(
+      'pub.dev API returned HTTP ${response.statusCode} for $packageName',
+    );
+  }
+
+  return responseBody;
+}
+
+class PubDevPackageNotFoundException implements Exception {
+  PubDevPackageNotFoundException(this.message);
+
+  final String message;
+}
+
+class PubDevFetchException implements Exception {
+  PubDevFetchException(this.message);
+
+  final String message;
+}
+
+class _WaitOptions {
+  const _WaitOptions({
+    required this.packageName,
+    required this.version,
+    required this.timeout,
+    required this.interval,
+  });
+
+  final String packageName;
+  final String version;
+  final Duration timeout;
+  final Duration interval;
+}
+
+_WaitOptions? _readOptions(List<String> arguments) {
+  String? packageName;
+  String? version;
+  var timeout = defaultPollTimeout;
+  var interval = defaultPollInterval;
+
+  for (var index = 0; index < arguments.length; index++) {
+    final argument = arguments[index];
+
+    if (argument == '--package') {
+      if (index + 1 >= arguments.length) {
+        stderr.writeln('Missing value for --package');
+        return null;
+      }
+      packageName = arguments[++index];
+      continue;
+    }
+
+    const packagePrefix = '--package=';
+    if (argument.startsWith(packagePrefix)) {
+      final value = argument.substring(packagePrefix.length);
+      if (value.isEmpty) {
+        stderr.writeln('Missing value for --package');
+        return null;
+      }
+      packageName = value;
+      continue;
+    }
+
+    if (argument == '--version') {
+      if (index + 1 >= arguments.length) {
+        stderr.writeln('Missing value for --version');
+        return null;
+      }
+      version = arguments[++index];
+      continue;
+    }
+
+    const versionPrefix = '--version=';
+    if (argument.startsWith(versionPrefix)) {
+      final value = argument.substring(versionPrefix.length);
+      if (value.isEmpty) {
+        stderr.writeln('Missing value for --version');
+        return null;
+      }
+      version = value;
+      continue;
+    }
+
+    if (argument == '--timeout') {
+      final parsed = _readDurationArgument(
+        arguments,
+        index,
+        defaultPollTimeout,
+        '--timeout',
+      );
+      if (parsed == null) {
+        return null;
+      }
+      timeout = parsed.value;
+      index = parsed.nextIndex;
+      continue;
+    }
+
+    const timeoutPrefix = '--timeout=';
+    if (argument.startsWith(timeoutPrefix)) {
+      final parsed = _parseDurationSeconds(
+        argument.substring(timeoutPrefix.length),
+        '--timeout',
+      );
+      if (parsed == null) {
+        return null;
+      }
+      timeout = parsed;
+      continue;
+    }
+
+    if (argument == '--interval') {
+      final parsed = _readDurationArgument(
+        arguments,
+        index,
+        defaultPollInterval,
+        '--interval',
+      );
+      if (parsed == null) {
+        return null;
+      }
+      interval = parsed.value;
+      index = parsed.nextIndex;
+      continue;
+    }
+
+    const intervalPrefix = '--interval=';
+    if (argument.startsWith(intervalPrefix)) {
+      final parsed = _parseDurationSeconds(
+        argument.substring(intervalPrefix.length),
+        '--interval',
+      );
+      if (parsed == null) {
+        return null;
+      }
+      interval = parsed;
+      continue;
+    }
+
+    stderr.writeln('Unknown argument: $argument');
+    return null;
+  }
+
+  if (packageName == null) {
+    stderr.writeln('Missing required --package argument');
+    return null;
+  }
+
+  if (version == null) {
+    stderr.writeln('Missing required --version argument');
+    return null;
+  }
+
+  return _WaitOptions(
+    packageName: packageName,
+    version: version,
+    timeout: timeout,
+    interval: interval,
+  );
+}
+
+({Duration value, int nextIndex})? _readDurationArgument(
+  List<String> arguments,
+  int index,
+  Duration defaultValue,
+  String flagName,
+) {
+  if (index + 1 >= arguments.length) {
+    stderr.writeln('Missing value for $flagName');
+    return null;
+  }
+
+  final parsed = _parseDurationSeconds(arguments[index + 1], flagName);
+  if (parsed == null) {
+    return null;
+  }
+
+  return (value: parsed, nextIndex: index + 1);
+}
+
+Duration? _parseDurationSeconds(String rawValue, String flagName) {
+  final seconds = int.tryParse(rawValue);
+  if (seconds == null || seconds <= 0) {
+    stderr.writeln(
+      'Invalid $flagName value: $rawValue (expected positive integer seconds)',
+    );
+    return null;
+  }
+
+  return Duration(seconds: seconds);
+}
+
+void _printUsage() {
+  stderr
+    ..writeln(
+      'Usage: dart run tool/wait_for_pub_dev_version/wait_for_pub_dev_version.dart '
+      '--package <name> --version <version> '
+      '[--timeout <seconds>] [--interval <seconds>]',
+    )
+    ..writeln()
+    ..writeln(
+      'Polls pub.dev until the exact version appears in the package API.',
+    )
+    ..writeln(
+      'Default timeout: ${defaultPollTimeout.inSeconds}s; '
+      'default interval: ${defaultPollInterval.inSeconds}s.',
+    )
+    ..writeln()
+    ..writeln('Supported packages: ${packageConfigs.keys.join(', ')}');
+}


### PR DESCRIPTION
## Summary
- Add `tool/wait_for_pub_dev_version/` (not a workspace member) with the pub.dev poll script and a one-entry `coverde` → `packages/coverde_cli` config.
- Independent of #322 (`tool/prepare_package_release`).

## Test plan
- [x] `cd tool/wait_for_pub_dev_version && dart pub get && dart test`