### PR TITLE
ci: disable Melos IntelliJ generation for dart install

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,12 @@ dev_dependencies:
     path: tools/pub_score_checker
 
 melos:
+  # dart install AOT binaries cannot resolve package:melos, so bootstrap
+  # crashes while writing IntelliJ templates (getMelosRoot null check).
+  ide:
+    intellij:
+      enabled: false
+
   categories:
     tools:
       - ./tools/**


### PR DESCRIPTION
## Summary
- Prepare Dart package release fails at `melos bs` after `dart pub get`: `getMelosRoot` null-checks because `dart install` ships an AOT binary with no `package:melos` URI.
- Disable Melos IntelliJ file generation. This repo does not keep `.iml` files, and CI/release do not need them.

## Test plan
- [x] Re-run **Prepare Dart package release** after merge (still needs annotated tag `coverde-v0.4.1` on the current `0.4.1` commit).