### PR TITLE
feat(t-prepare-package-release): add configurable auto-bump policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,8 +96,6 @@ Live pub.dev publishes use **GitHub OIDC** via [`dart-lang/setup-dart@v1`](https
 
 Create the GitHub environment `pub-dev-publish` with required reviewers. After the first successful OIDC publish, remove any leftover `PUB_CREDENTIALS` secret.
 
-**Baseline tag:** `main` is `0.4.1` but the latest historical tag is `coverde-v0.4.0`. Create annotated tag `coverde-v0.4.1` on the `0.4.1` commit before the first automated prepare, or the safety gate fails (`pubspecAheadOfTag`).
-
 ### CI release workflows
 
 Regular [Dart CI](.github/workflows/ci.yaml) does not run `release.check` or publish. Release automation uses four dedicated workflows:
@@ -120,7 +118,11 @@ Regular [Dart CI](.github/workflows/ci.yaml) does not run `release.check` or pub
        --cwd packages/coverde_cli \
        --tag-format '{name}-v{version}' \
        --scopes coverde-cli \
-       --commit-types feat,fix,docs,refactor,perf,test,build,chore
+       --commit-types feat,fix,docs,refactor,perf,test,build,chore \
+       --major-types '' \
+       --minor-types feat!,fix! \
+       --patch-types feat,fix \
+       --build-types docs,refactor,perf,test,build,chore
      ```
 3. **Review the release PR.** Confirm version, changelog, and generated `packageVersion`.
 4. **Wait for release PR CI.** [Dart release PR check](.github/workflows/release-pr.yaml) runs scoped `release.check`.
@@ -129,12 +131,14 @@ Regular [Dart CI](.github/workflows/ci.yaml) does not run `release.check` or pub
    - **Failure recovery:** If publish or the poll fails, the workflow deletes the tag. Recreate it with **Release tag on merge** (`workflow_dispatch` on `main`), then dispatch publish again.
    - **Pre-publish gate:** Dispatch the same workflow with `dry_run: true` to run `release.check` only.
 
-Auto-bump rules (stable versions):
+Auto-bump is policy-driven. `release.prepare` passes coverde's `0.x` map (no constructor defaults in the tool):
 
-- `feat` → minor (`0.4.1` → `0.5.0`)
-- `fix` → patch (`0.4.1` → `0.4.2`)
-- other allowed types only → build (`0.4.1` → `0.4.1+1`)
-- breaking `feat` in `0.x` → minor; once `major >= 1`, breaking `feat` → major
+- `--major-types` empty — auto-bump never produces `1.0.0`
+- breaking `feat` / `fix` (`feat!`, `fix!`, or a `BREAKING CHANGE` footer) → minor (`0.4.0` → `0.5.0`)
+- non-breaking `feat` or `fix` → patch (`0.4.0` → `0.4.1`)
+- `docs`, `refactor`, `perf`, `test`, `build`, `chore` → build (`0.4.0` → `0.4.0+1`)
+
+Highest matching component wins. A breaking type not listed as `type!` falls back to `type` (`chore!` still bumps build). Promoting to 1.x SemVer later is a Melos flag change (`--major-types feat!,fix!`, `--minor-types feat`, …).
 
 ### How CI scopes `release.check`
 
@@ -149,8 +153,12 @@ Auto-bump rules (stable versions):
 | `--cwd` | Package root (`packages/coverde_cli`). |
 | `--tag-format` | Embedded value: `'{name}-v{version}'` (for example `coverde-v0.4.1`). |
 | `--scopes` | Embedded value: `coverde-cli`. |
-| `--commit-types` | Embedded value: `feat,fix,docs,refactor,perf,test,build,chore`. |
-| *(no `--bump`)* | Auto-bump from scoped commits. |
+| `--commit-types` | Embedded value: `feat,fix,docs,refactor,perf,test,build,chore`. Changelog inclusion filter. |
+| `--major-types` | Embedded value: empty. Types that bump major. Required; empty opts out of `1.0.0`. |
+| `--minor-types` | Embedded value: `feat!,fix!`. Types that bump minor. Required. |
+| `--patch-types` | Embedded value: `feat,fix`. Types that bump patch. Required. |
+| `--build-types` | Embedded value: `docs,refactor,perf,test,build,chore`. Types that bump `+N`. Required. |
+| *(no `--bump`)* | Auto-bump from scoped commits using the type-set policy. |
 | `--bump patch\|minor\|major\|build` | Explicit segment bump (direct tool invocation). |
 | `--version <semver>` | Exact target version. Mutually exclusive with `--bump`. |
 | `--allow-unsafe-bump` | Skip the tag/pubspec equality safety gate. |

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -204,6 +204,10 @@ melos:
         --tag-format '{name}-v{version}'
         --scopes coverde-cli
         --commit-types feat,fix,docs,refactor,perf,test,build,chore
+        --major-types=
+        --minor-types feat!,fix!
+        --patch-types feat,fix
+        --build-types docs,refactor,perf,test,build,chore
         --apply
         &&
         dart run build_runner build --delete-conflicting-outputs

--- a/tool/prepare_package_release/prepare_package_release.dart
+++ b/tool/prepare_package_release/prepare_package_release.dart
@@ -1031,8 +1031,8 @@ enum ReleaseSafetyFailure {
       failure: ReleaseSafetyFailure.pubspecAheadOfTag,
       errorMessage:
           'Package version $currentVersion is ahead of latest release '
-          'tag $latestTag ($latestTagVersion). '
-          'Expected tag for current version: $expectedTag.',
+              'tag $latestTag ($latestTagVersion). '
+              'Expected tag for current version: $expectedTag.',
     );
   }
 
@@ -1041,8 +1041,8 @@ enum ReleaseSafetyFailure {
     failure: ReleaseSafetyFailure.pubspecBehindTag,
     errorMessage:
         'Package version $currentVersion is behind latest release tag '
-        '$latestTag ($latestTagVersion). Update pubspec version to match '
-        'the latest tag or pass --allow-unsafe-bump for local recovery.',
+            '$latestTag ($latestTagVersion). Update pubspec version to match '
+            'the latest tag or pass --allow-unsafe-bump for local recovery.',
   );
 }
 

--- a/tool/prepare_package_release/prepare_package_release.dart
+++ b/tool/prepare_package_release/prepare_package_release.dart
@@ -793,8 +793,7 @@ Version applyAutoVersionBump({
     );
   }
 
-  final impact = determineAutoBumpImpact(commits: commits, policy: policy);
-  if (impact == null) {
+  if (determineAutoBumpImpact(commits: commits, policy: policy) == null) {
     return (
       nextVersion: null,
       errorMessage: 'No conventional commits available for auto version bump.',
@@ -802,9 +801,10 @@ Version applyAutoVersionBump({
   }
 
   return (
-    nextVersion: applyImpactVersionBump(
+    nextVersion: applyAutoVersionBump(
       current: currentVersion,
-      impact: impact,
+      commits: commits,
+      policy: policy,
     ),
     errorMessage: null,
   );
@@ -1494,6 +1494,15 @@ void printPrepareReleaseUsage() {
     )
     ..writeln()
     ..writeln(buildPrepareReleaseArgParser().usage);
+  if (!devReleasePolicyFactoryIsRegistered()) {
+    stderr.writeln('Unimplemented: AutoVersionBumpPolicy.devRelease');
+  }
+}
+
+/// Whether the unimplemented [AutoVersionBumpPolicy.devRelease] factory is
+/// linked into this executable.
+bool devReleasePolicyFactoryIsRegistered() {
+  return AutoVersionBumpPolicy.devRelease.toString().isNotEmpty;
 }
 
 /// Parses CLI arguments for the prepare release tool.
@@ -1615,7 +1624,12 @@ PrepareReleaseCliOptions? parsePrepareReleaseCliOptions(
       tagFormat: tagFormat,
       commitTypes: commitTypes,
       scopes: scopes != null && scopes.isNotEmpty ? scopes : null,
-      policy: policyResult.policy,
+      policy: AutoVersionBumpPolicy(
+        major: majorResult.types!,
+        minor: minorResult.types!,
+        patch: patchResult.types!,
+        buildNumber: buildResult.types!,
+      ),
       explicitBump: explicitBump,
       explicitVersionText: explicitVersionText,
       allowUnsafeBump: results['allow-unsafe-bump'] as bool? ?? false,

--- a/tool/prepare_package_release/prepare_package_release.dart
+++ b/tool/prepare_package_release/prepare_package_release.dart
@@ -440,51 +440,280 @@ enum AutoBumpImpact {
   build,
 }
 
-/// Derives the highest semver impact from filtered [commits].
-AutoBumpImpact determineAutoBumpImpact(List<ConventionalCommit> commits) {
-  var hasBreakingFeat = false;
-  var hasFeat = false;
-  var hasFix = false;
+final _policyTokenPattern = RegExp(r'^([a-z]+)(!)?$');
+
+/// Maps conventional commit types (with optional `!`) to semver components.
+///
+/// All four sets are required. A single set may be empty. Every set empty is
+/// invalid because auto-bump could never choose a component.
+class AutoVersionBumpPolicy {
+  factory AutoVersionBumpPolicy({
+    required Set<String> major,
+    required Set<String> minor,
+    required Set<String> patch,
+    required Set<String> buildNumber,
+  }) {
+    final parsed = parseAutoVersionBumpPolicy(
+      major: major,
+      minor: minor,
+      patch: patch,
+      buildNumber: buildNumber,
+    );
+    if (parsed.errorMessage != null) {
+      throw ArgumentError(parsed.errorMessage);
+    }
+    return parsed.policy!;
+  }
+
+  AutoVersionBumpPolicy._({
+    required this.major,
+    required this.minor,
+    required this.patch,
+    required this.buildNumber,
+  });
+
+  /// Prerelease auto-bump policy. Not implemented yet.
+  factory AutoVersionBumpPolicy.devRelease({required String prefix}) {
+    throw UnimplementedError(
+      'AutoVersionBumpPolicy.devRelease(prefix: $prefix) '
+      'is not implemented yet.',
+    );
+  }
+
+  final Set<String> major;
+  final Set<String> minor;
+  final Set<String> patch;
+  final Set<String> buildNumber;
+}
+
+/// Parses a single policy token such as `feat` or `feat!`.
+({String? token, String? errorMessage}) parseAutoBumpPolicyToken(String input) {
+  final trimmed = input.trim().toLowerCase();
+  if (trimmed.isEmpty) {
+    return (token: null, errorMessage: 'Policy type token must not be empty.');
+  }
+
+  final match = _policyTokenPattern.firstMatch(trimmed);
+  if (match == null) {
+    return (
+      token: null,
+      errorMessage: 'Invalid policy type token: $input. '
+          'Expected a conventional commit type, optionally ending with !.',
+    );
+  }
+
+  final type = match.group(1)!;
+  if (!supportedConventionalCommitTypes.contains(type)) {
+    return (
+      token: null,
+      errorMessage: 'Unknown commit type(s): $input',
+    );
+  }
+
+  final isBreaking = match.group(2) != null;
+  return (token: isBreaking ? '$type!' : type, errorMessage: null);
+}
+
+/// Parses a comma-separated policy type set. An empty string is an empty set.
+({Set<String>? types, String? errorMessage}) parseAutoBumpTypeSet(
+  String input,
+) {
+  final tokens = <String>{};
+  final segments = input
+      .split(',')
+      .map((segment) => segment.trim())
+      .where((segment) => segment.isNotEmpty);
+
+  for (final segment in segments) {
+    final parsed = parseAutoBumpPolicyToken(segment);
+    if (parsed.errorMessage != null) {
+      return (types: null, errorMessage: parsed.errorMessage);
+    }
+    tokens.add(parsed.token!);
+  }
+
+  return (types: tokens, errorMessage: null);
+}
+
+String? _autoBumpPolicyOverlapError({
+  required Set<String> major,
+  required Set<String> minor,
+  required Set<String> patch,
+  required Set<String> buildNumber,
+}) {
+  final seen = <String, String>{};
+
+  String? addAll(String component, Set<String> types) {
+    for (final token in types) {
+      final existing = seen[token];
+      if (existing != null) {
+        return 'Policy type "$token" is listed in both $existing and '
+            '$component.';
+      }
+      seen[token] = component;
+    }
+    return null;
+  }
+
+  return addAll('major', major) ??
+      addAll('minor', minor) ??
+      addAll('patch', patch) ??
+      addAll('build', buildNumber);
+}
+
+/// Validates and copies type sets into an [AutoVersionBumpPolicy].
+({AutoVersionBumpPolicy? policy, String? errorMessage})
+    parseAutoVersionBumpPolicy({
+  required Set<String> major,
+  required Set<String> minor,
+  required Set<String> patch,
+  required Set<String> buildNumber,
+}) {
+  ({Set<String>? types, String? errorMessage}) normalize(Set<String> input) {
+    final tokens = <String>{};
+    for (final token in input) {
+      final parsed = parseAutoBumpPolicyToken(token);
+      if (parsed.errorMessage != null) {
+        return (types: null, errorMessage: parsed.errorMessage);
+      }
+      tokens.add(parsed.token!);
+    }
+    return (types: tokens, errorMessage: null);
+  }
+
+  final normalizedMajor = normalize(major);
+  if (normalizedMajor.errorMessage != null) {
+    return (policy: null, errorMessage: normalizedMajor.errorMessage);
+  }
+  final normalizedMinor = normalize(minor);
+  if (normalizedMinor.errorMessage != null) {
+    return (policy: null, errorMessage: normalizedMinor.errorMessage);
+  }
+  final normalizedPatch = normalize(patch);
+  if (normalizedPatch.errorMessage != null) {
+    return (policy: null, errorMessage: normalizedPatch.errorMessage);
+  }
+  final normalizedBuild = normalize(buildNumber);
+  if (normalizedBuild.errorMessage != null) {
+    return (policy: null, errorMessage: normalizedBuild.errorMessage);
+  }
+
+  final overlap = _autoBumpPolicyOverlapError(
+    major: normalizedMajor.types!,
+    minor: normalizedMinor.types!,
+    patch: normalizedPatch.types!,
+    buildNumber: normalizedBuild.types!,
+  );
+  if (overlap != null) {
+    return (policy: null, errorMessage: overlap);
+  }
+
+  if (normalizedMajor.types!.isEmpty &&
+      normalizedMinor.types!.isEmpty &&
+      normalizedPatch.types!.isEmpty &&
+      normalizedBuild.types!.isEmpty) {
+    return (
+      policy: null,
+      errorMessage: 'Auto-bump policy must include at least one commit type.',
+    );
+  }
+
+  return (
+    policy: AutoVersionBumpPolicy._(
+      major: Set<String>.unmodifiable(normalizedMajor.types!),
+      minor: Set<String>.unmodifiable(normalizedMinor.types!),
+      patch: Set<String>.unmodifiable(normalizedPatch.types!),
+      buildNumber: Set<String>.unmodifiable(normalizedBuild.types!),
+    ),
+    errorMessage: null,
+  );
+}
+
+/// Returns the policy key for [commit]: `type!` when breaking, else `type`.
+String autoBumpPolicyKey(ConventionalCommit commit) {
+  if (hasBreakingChange(commit)) {
+    return '${commit.type}!';
+  }
+  return commit.type;
+}
+
+AutoBumpImpact? _impactForPolicyKey(
+  String key,
+  AutoVersionBumpPolicy policy,
+) {
+  if (policy.major.contains(key)) {
+    return AutoBumpImpact.major;
+  }
+  if (policy.minor.contains(key)) {
+    return AutoBumpImpact.minor;
+  }
+  if (policy.patch.contains(key)) {
+    return AutoBumpImpact.patch;
+  }
+  if (policy.buildNumber.contains(key)) {
+    return AutoBumpImpact.build;
+  }
+  return null;
+}
+
+/// Resolves [commit] against [policy], falling back from `type!` to `type`.
+AutoBumpImpact? autoBumpImpactForCommit({
+  required ConventionalCommit commit,
+  required AutoVersionBumpPolicy policy,
+}) {
+  final key = autoBumpPolicyKey(commit);
+  final impact = _impactForPolicyKey(key, policy);
+  if (impact != null) {
+    return impact;
+  }
+  if (key.endsWith('!')) {
+    return _impactForPolicyKey(commit.type, policy);
+  }
+  return null;
+}
+
+int _autoBumpImpactRank(AutoBumpImpact impact) {
+  switch (impact) {
+    case AutoBumpImpact.major:
+      return 4;
+    case AutoBumpImpact.minor:
+      return 3;
+    case AutoBumpImpact.patch:
+      return 2;
+    case AutoBumpImpact.build:
+      return 1;
+  }
+}
+
+/// Derives the highest semver impact from filtered [commits] using [policy].
+///
+/// Returns `null` when no commit matches any policy set.
+AutoBumpImpact? determineAutoBumpImpact({
+  required List<ConventionalCommit> commits,
+  required AutoVersionBumpPolicy policy,
+}) {
+  AutoBumpImpact? highest;
 
   for (final commit in commits) {
-    switch (commit.type) {
-      case 'feat':
-        if (hasBreakingChange(commit)) {
-          hasBreakingFeat = true;
-        } else {
-          hasFeat = true;
-        }
-      case 'fix':
-        hasFix = true;
-      default:
-        break;
+    final impact = autoBumpImpactForCommit(commit: commit, policy: policy);
+    if (impact == null) {
+      continue;
+    }
+    if (highest == null ||
+        _autoBumpImpactRank(impact) > _autoBumpImpactRank(highest)) {
+      highest = impact;
     }
   }
 
-  if (hasBreakingFeat) {
-    return AutoBumpImpact.major;
-  }
-  if (hasFeat) {
-    return AutoBumpImpact.minor;
-  }
-  if (hasFix) {
-    return AutoBumpImpact.patch;
-  }
-  return AutoBumpImpact.build;
+  return highest;
 }
 
-/// Applies auto bump rules from [commits] to [current].
-///
-/// In `0.x`, a breaking feat bumps minor (not major) to match coverde history.
-Version applyAutoVersionBump({
+Version applyImpactVersionBump({
   required Version current,
-  required List<ConventionalCommit> commits,
+  required AutoBumpImpact impact,
 }) {
-  switch (determineAutoBumpImpact(commits)) {
+  switch (impact) {
     case AutoBumpImpact.major:
-      if (current.major == 0) {
-        return Version(0, current.minor + 1, 0);
-      }
       return Version(current.major + 1, 0, 0);
     case AutoBumpImpact.minor:
       return Version(current.major, current.minor + 1, 0);
@@ -498,15 +727,32 @@ Version applyAutoVersionBump({
   }
 }
 
+/// Applies auto bump rules from [commits] to [current] using [policy].
+Version applyAutoVersionBump({
+  required Version current,
+  required List<ConventionalCommit> commits,
+  required AutoVersionBumpPolicy policy,
+}) {
+  final impact = determineAutoBumpImpact(commits: commits, policy: policy);
+  if (impact == null) {
+    throw StateError(
+      'No conventional commits available for auto version bump.',
+    );
+  }
+  return applyImpactVersionBump(current: current, impact: impact);
+}
+
 /// Computes the next stable version from [currentVersion].
 ///
 /// When [explicitBump] and [explicitVersionText] are both set, returns a
-/// structured error. Auto mode requires at least one commit.
+/// structured error. Auto mode requires [policy] and at least one matching
+/// commit.
 ({Version? nextVersion, String? errorMessage}) computeNextVersion({
   required Version currentVersion,
   ExplicitVersionBump? explicitBump,
   String? explicitVersionText,
   List<ConventionalCommit> commits = const [],
+  AutoVersionBumpPolicy? policy,
 }) {
   if (explicitBump != null && explicitVersionText != null) {
     return (
@@ -533,6 +779,13 @@ Version applyAutoVersionBump({
     );
   }
 
+  if (policy == null) {
+    return (
+      nextVersion: null,
+      errorMessage: 'Auto version bump requires a policy.',
+    );
+  }
+
   if (commits.isEmpty) {
     return (
       nextVersion: null,
@@ -540,10 +793,18 @@ Version applyAutoVersionBump({
     );
   }
 
+  final impact = determineAutoBumpImpact(commits: commits, policy: policy);
+  if (impact == null) {
+    return (
+      nextVersion: null,
+      errorMessage: 'No conventional commits available for auto version bump.',
+    );
+  }
+
   return (
-    nextVersion: applyAutoVersionBump(
+    nextVersion: applyImpactVersionBump(
       current: currentVersion,
-      commits: commits,
+      impact: impact,
     ),
     errorMessage: null,
   );
@@ -770,8 +1031,8 @@ enum ReleaseSafetyFailure {
       failure: ReleaseSafetyFailure.pubspecAheadOfTag,
       errorMessage:
           'Package version $currentVersion is ahead of latest release '
-              'tag $latestTag ($latestTagVersion). '
-              'Expected tag for current version: $expectedTag.',
+          'tag $latestTag ($latestTagVersion). '
+          'Expected tag for current version: $expectedTag.',
     );
   }
 
@@ -780,8 +1041,8 @@ enum ReleaseSafetyFailure {
     failure: ReleaseSafetyFailure.pubspecBehindTag,
     errorMessage:
         'Package version $currentVersion is behind latest release tag '
-            '$latestTag ($latestTagVersion). Update pubspec version to match '
-            'the latest tag or pass --allow-unsafe-bump for local recovery.',
+        '$latestTag ($latestTagVersion). Update pubspec version to match '
+        'the latest tag or pass --allow-unsafe-bump for local recovery.',
   );
 }
 
@@ -934,6 +1195,7 @@ class PrepareReleasePlan {
   required String cwd,
   required String tagFormat,
   required String commitTypesInput,
+  required AutoVersionBumpPolicy policy,
   String? scopesInput,
   bool allowUnsafeBump = false,
   ExplicitVersionBump? explicitBump,
@@ -1001,6 +1263,7 @@ class PrepareReleasePlan {
     explicitBump: explicitBump,
     explicitVersionText: explicitVersionText,
     commits: commits,
+    policy: policy,
   );
   if (nextVersionResult.errorMessage != null) {
     return (plan: null, errorMessage: nextVersionResult.errorMessage);
@@ -1183,6 +1446,25 @@ ArgParser buildPrepareReleaseArgParser() {
           'Defaults to the package name from pubspec.yaml.',
     )
     ..addOption(
+      'major-types',
+      help: 'Comma-separated policy types that bump major. '
+          'Required. Empty means major is never auto-bumped. '
+          'Use type! for breaking commits (e.g. feat!).',
+    )
+    ..addOption(
+      'minor-types',
+      help: 'Comma-separated policy types that bump minor. Required.',
+    )
+    ..addOption(
+      'patch-types',
+      help: 'Comma-separated policy types that bump patch. Required.',
+    )
+    ..addOption(
+      'build-types',
+      help: 'Comma-separated policy types that bump build metadata (+N). '
+          'Required.',
+    )
+    ..addOption(
       'bump',
       help: 'Explicit semver bump (build, patch, minor, major). '
           'Mutually exclusive with --version.',
@@ -1279,11 +1561,61 @@ PrepareReleaseCliOptions? parsePrepareReleaseCliOptions(
 
     final scopes = results['scopes'] as String?;
 
+    final majorTypes = _requireParsedOption(results, 'major-types');
+    if (majorTypes == null) {
+      return null;
+    }
+    final minorTypes = _requireParsedOption(results, 'minor-types');
+    if (minorTypes == null) {
+      return null;
+    }
+    final patchTypes = _requireParsedOption(results, 'patch-types');
+    if (patchTypes == null) {
+      return null;
+    }
+    final buildTypes = _requireParsedOption(results, 'build-types');
+    if (buildTypes == null) {
+      return null;
+    }
+
+    final majorResult = parseAutoBumpTypeSet(majorTypes);
+    if (majorResult.errorMessage != null) {
+      stderr.writeln(majorResult.errorMessage);
+      return null;
+    }
+    final minorResult = parseAutoBumpTypeSet(minorTypes);
+    if (minorResult.errorMessage != null) {
+      stderr.writeln(minorResult.errorMessage);
+      return null;
+    }
+    final patchResult = parseAutoBumpTypeSet(patchTypes);
+    if (patchResult.errorMessage != null) {
+      stderr.writeln(patchResult.errorMessage);
+      return null;
+    }
+    final buildResult = parseAutoBumpTypeSet(buildTypes);
+    if (buildResult.errorMessage != null) {
+      stderr.writeln(buildResult.errorMessage);
+      return null;
+    }
+
+    final policyResult = parseAutoVersionBumpPolicy(
+      major: majorResult.types!,
+      minor: minorResult.types!,
+      patch: patchResult.types!,
+      buildNumber: buildResult.types!,
+    );
+    if (policyResult.errorMessage != null) {
+      stderr.writeln(policyResult.errorMessage);
+      return null;
+    }
+
     return PrepareReleaseCliOptions(
       cwd: cwd,
       tagFormat: tagFormat,
       commitTypes: commitTypes,
       scopes: scopes != null && scopes.isNotEmpty ? scopes : null,
+      policy: policyResult.policy,
       explicitBump: explicitBump,
       explicitVersionText: explicitVersionText,
       allowUnsafeBump: results['allow-unsafe-bump'] as bool? ?? false,
@@ -1303,6 +1635,7 @@ class PrepareReleaseCliOptions {
     this.tagFormat,
     this.commitTypes,
     this.scopes,
+    this.policy,
     this.explicitBump,
     this.explicitVersionText,
     this.allowUnsafeBump = false,
@@ -1314,10 +1647,19 @@ class PrepareReleaseCliOptions {
   final String? tagFormat;
   final String? commitTypes;
   final String? scopes;
+  final AutoVersionBumpPolicy? policy;
   final ExplicitVersionBump? explicitBump;
   final String? explicitVersionText;
   final bool allowUnsafeBump;
   final bool apply;
+}
+
+String? _requireParsedOption(ArgResults results, String name) {
+  if (!results.wasParsed(name)) {
+    stderr.writeln('Missing value for --$name');
+    return null;
+  }
+  return results[name] as String? ?? '';
 }
 
 void main(List<String> arguments) {
@@ -1336,6 +1678,7 @@ void main(List<String> arguments) {
     cwd: options.cwd!,
     tagFormat: options.tagFormat!,
     commitTypesInput: options.commitTypes!,
+    policy: options.policy!,
     scopesInput: options.scopes,
     allowUnsafeBump: options.allowUnsafeBump,
     explicitBump: options.explicitBump,

--- a/tool/prepare_package_release/test/fixtures/version_bump_cases.json
+++ b/tool/prepare_package_release/test/fixtures/version_bump_cases.json
@@ -1,5 +1,11 @@
 {
   "currentVersion": "0.4.1",
+  "policy": {
+    "major": [],
+    "minor": ["feat!", "fix!"],
+    "patch": ["feat", "fix"],
+    "buildNumber": ["docs", "refactor", "perf", "test", "build", "chore"]
+  },
   "cases": [
     {
       "name": "docs-only increments build metadata",
@@ -30,7 +36,7 @@
       "expectedVersion": "0.4.2"
     },
     {
-      "name": "feat increments minor",
+      "name": "feat increments patch",
       "commits": [
         {
           "type": "feat",
@@ -41,7 +47,7 @@
           "subject": "feat(coverde-cli): add preview command"
         }
       ],
-      "expectedVersion": "0.5.0"
+      "expectedVersion": "0.4.2"
     },
     {
       "name": "0.x breaking feat increments minor",
@@ -53,6 +59,21 @@
           ],
           "description": "drop legacy flag",
           "subject": "feat(coverde-cli)!: drop legacy flag",
+          "isBreakingChange": true
+        }
+      ],
+      "expectedVersion": "0.5.0"
+    },
+    {
+      "name": "0.x breaking fix increments minor",
+      "commits": [
+        {
+          "type": "fix",
+          "scopes": [
+            "coverde-cli"
+          ],
+          "description": "drop legacy path handling",
+          "subject": "fix(coverde-cli)!: drop legacy path handling",
           "isBreakingChange": true
         }
       ],
@@ -74,7 +95,7 @@
       "expectedVersion": "0.5.0"
     },
     {
-      "name": "feat wins over fix and docs",
+      "name": "feat and fix increment patch not minor",
       "commits": [
         {
           "type": "docs",
@@ -101,7 +122,22 @@
           "subject": "feat(coverde-cli): add preview"
         }
       ],
-      "expectedVersion": "0.5.0"
+      "expectedVersion": "0.4.2"
+    },
+    {
+      "name": "breaking chore falls back to chore build bump",
+      "commits": [
+        {
+          "type": "chore",
+          "scopes": [
+            "coverde-cli"
+          ],
+          "description": "reshape internals",
+          "subject": "chore(coverde-cli)!: reshape internals",
+          "isBreakingChange": true
+        }
+      ],
+      "expectedVersion": "0.4.1+1"
     }
   ]
 }

--- a/tool/prepare_package_release/test/prepare_package_release_test.dart
+++ b/tool/prepare_package_release/test/prepare_package_release_test.dart
@@ -6,6 +6,55 @@ import 'package:test/test.dart';
 
 import '../prepare_package_release.dart';
 
+final _zeroMajorPolicy = AutoVersionBumpPolicy(
+  major: {},
+  minor: {'feat!', 'fix!'},
+  patch: {'feat', 'fix'},
+  buildNumber: {
+    'docs',
+    'refactor',
+    'perf',
+    'test',
+    'build',
+    'chore',
+  },
+);
+
+final _semver1Policy = AutoVersionBumpPolicy(
+  major: {'feat!', 'fix!'},
+  minor: {'feat'},
+  patch: {'fix'},
+  buildNumber: {
+    'docs',
+    'refactor',
+    'perf',
+    'test',
+    'build',
+    'chore',
+  },
+);
+
+const _zeroMajorPolicyCliArgs = <String>[
+  '--major-types',
+  '',
+  '--minor-types',
+  'feat!,fix!',
+  '--patch-types',
+  'feat,fix',
+  '--build-types',
+  'docs,refactor,perf,test,build,chore',
+];
+
+AutoVersionBumpPolicy _policyFromFixture(Map<Object?, Object?> fixture) {
+  final policy = fixture['policy']! as Map;
+  return AutoVersionBumpPolicy(
+    major: (policy['major'] as List).cast<String>().toSet(),
+    minor: (policy['minor'] as List).cast<String>().toSet(),
+    patch: (policy['patch'] as List).cast<String>().toSet(),
+    buildNumber: (policy['buildNumber'] as List).cast<String>().toSet(),
+  );
+}
+
 void main() {
   late Directory tempRoot;
 
@@ -927,14 +976,19 @@ issue_tracker: https://github.com/example/clay/issues
         final expected = Version.parse(testCase['expectedVersion'] as String);
 
         expect(
-          applyAutoVersionBump(current: currentVersion, commits: commits),
+          applyAutoVersionBump(
+            current: currentVersion,
+            commits: commits,
+            policy: _policyFromFixture(fixture),
+          ),
           expected,
           reason: testCase['name'] as String,
         );
       }
     });
 
-    test('1.x breaking feat increments major', () {
+    test('1.x breaking feat increments major when policy maps feat! to major',
+        () {
       expect(
         applyAutoVersionBump(
           current: Version.parse('1.2.3'),
@@ -947,8 +1001,78 @@ issue_tracker: https://github.com/example/clay/issues
               isBreakingChange: true,
             ),
           ],
+          policy: _semver1Policy,
         ),
         Version.parse('2.0.0'),
+      );
+    });
+
+    test('1.x feat increments minor when policy maps feat to minor', () {
+      expect(
+        applyAutoVersionBump(
+          current: Version.parse('1.2.3'),
+          commits: const [
+            ConventionalCommit(
+              type: 'feat',
+              scopes: ['coverde-cli'],
+              description: 'add preview command',
+              subject: 'feat(coverde-cli): add preview command',
+              isBreakingChange: false,
+            ),
+          ],
+          policy: _semver1Policy,
+        ),
+        Version.parse('1.3.0'),
+      );
+    });
+  });
+
+  group('AutoVersionBumpPolicy', () {
+    test('accepts an empty major set when other sets are populated', () {
+      expect(_zeroMajorPolicy.major, isEmpty);
+      expect(_zeroMajorPolicy.patch, contains('feat'));
+    });
+
+    test('throws when every component set is empty', () {
+      expect(
+        () => AutoVersionBumpPolicy(
+          major: {},
+          minor: {},
+          patch: {},
+          buildNumber: {},
+        ),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.message,
+            'message',
+            contains('at least one commit type'),
+          ),
+        ),
+      );
+    });
+
+    test('throws when the same token appears in two sets', () {
+      expect(
+        () => AutoVersionBumpPolicy(
+          major: {},
+          minor: {'feat'},
+          patch: {'feat'},
+          buildNumber: {'docs'},
+        ),
+        throwsA(
+          isA<ArgumentError>().having(
+            (error) => error.message,
+            'message',
+            contains('listed in both'),
+          ),
+        ),
+      );
+    });
+
+    test('devRelease is unimplemented', () {
+      expect(
+        () => AutoVersionBumpPolicy.devRelease(prefix: '-dev.'),
+        throwsA(isA<UnimplementedError>()),
       );
     });
   });
@@ -968,6 +1092,7 @@ issue_tracker: https://github.com/example/clay/issues
             isBreakingChange: false,
           ),
         ],
+        policy: _zeroMajorPolicy,
       );
 
       expect(result.errorMessage, isNull);
@@ -1015,7 +1140,34 @@ issue_tracker: https://github.com/example/clay/issues
     });
 
     test('rejects auto mode without commits', () {
-      final result = computeNextVersion(currentVersion: current);
+      final result = computeNextVersion(
+        currentVersion: current,
+        policy: _zeroMajorPolicy,
+      );
+
+      expect(result.nextVersion, isNull);
+      expect(result.errorMessage, contains('No conventional commits'));
+    });
+
+    test('rejects auto mode when no commit matches the policy', () {
+      final result = computeNextVersion(
+        currentVersion: current,
+        policy: AutoVersionBumpPolicy(
+          major: {},
+          minor: {'feat!'},
+          patch: {'feat'},
+          buildNumber: {},
+        ),
+        commits: [
+          const ConventionalCommit(
+            type: 'docs',
+            scopes: ['coverde-cli'],
+            description: 'update readme',
+            subject: 'docs(coverde-cli): update readme',
+            isBreakingChange: false,
+          ),
+        ],
+      );
 
       expect(result.nextVersion, isNull);
       expect(result.errorMessage, contains('No conventional commits'));
@@ -1554,6 +1706,7 @@ issue_tracker: https://github.com/example/clay/issues
         cwd: packageDir.path,
         tagFormat: '{name}/{version}',
         commitTypesInput: 'feat,fix,docs,refactor,test,build',
+        policy: _zeroMajorPolicy,
       );
 
       expect(result.errorMessage, isNull);
@@ -1561,12 +1714,12 @@ issue_tracker: https://github.com/example/clay/issues
       expect(plan.packageName, 'synthetic_pkg');
       expect(plan.latestTag, 'synthetic_pkg/0.0.1-dev.2');
       expect(plan.currentVersion, Version.parse('0.0.1-dev.2'));
-      expect(plan.nextVersion, Version.parse('0.1.0'));
+      expect(plan.nextVersion, Version.parse('0.0.2'));
       expect(plan.commits, hasLength(2));
-      expect(plan.changelogSection, contains('## 0.1.0'));
+      expect(plan.changelogSection, contains('## 0.0.2'));
       expect(
         plan.suggestedCommitMessage,
-        'chore(synthetic_pkg): release 0.1.0',
+        'chore(synthetic_pkg): release 0.0.2',
       );
     });
 
@@ -1596,13 +1749,14 @@ issue_tracker: https://github.com/example/clay/issues
         tagFormat: '{name}-v{version}',
         commitTypesInput: 'feat,fix,docs,refactor,perf,test,build,chore',
         scopesInput: 'coverde-cli',
+        policy: _zeroMajorPolicy,
       );
 
       expect(result.errorMessage, isNull);
       final plan = result.plan!;
       expect(plan.packageName, 'coverde');
       expect(plan.latestTag, 'coverde-v0.4.1');
-      expect(plan.nextVersion, Version.parse('0.5.0'));
+      expect(plan.nextVersion, Version.parse('0.4.2'));
       expect(plan.commits, hasLength(1));
       expect(
         plan.commits.single.subject,
@@ -1610,7 +1764,7 @@ issue_tracker: https://github.com/example/clay/issues
       );
       expect(
         plan.suggestedCommitMessage,
-        'chore(coverde): release 0.5.0',
+        'chore(coverde): release 0.4.2',
       );
     });
 
@@ -1638,6 +1792,7 @@ issue_tracker: https://github.com/example/clay/issues
         tagFormat: '{name}/{version}',
         commitTypesInput: 'feat,fix,docs,refactor,test,build',
         explicitBump: ExplicitVersionBump.build,
+        policy: _zeroMajorPolicy,
       );
 
       expect(result.errorMessage, isNull);
@@ -1729,6 +1884,7 @@ version: "0.0.1-dev.2"
         cwd: packageDir.path,
         tagFormat: '{name}/{version}',
         commitTypesInput: 'feat,fix,docs,refactor,test,build',
+        policy: _zeroMajorPolicy,
       );
       expect(planResult.errorMessage, isNull);
       return planResult.plan!;
@@ -1748,12 +1904,12 @@ version: "0.0.1-dev.2"
       expect(result.errorMessage, isNull);
       expect(
         readPubspecNameAndVersion(pubspecFile).version,
-        '0.1.0',
+        '0.0.2',
       );
       expect(pubspecFile.readAsStringSync(), isNot(pubspecBefore));
       expect(
         changelogFile.readAsStringSync(),
-        startsWith('## 0.1.0'),
+        startsWith('## 0.0.2'),
       );
       expect(
         changelogFile.readAsStringSync(),
@@ -1786,6 +1942,7 @@ environment:
         cwd: packageDir.path,
         tagFormat: '{name}/{version}',
         commitTypesInput: 'feat,fix,docs,refactor,test,build',
+        policy: _zeroMajorPolicy,
       );
       expect(planResult.errorMessage, isNull);
 
@@ -1796,7 +1953,7 @@ environment:
           File('${packageDir.path}/pubspec.yaml').readAsStringSync();
       expect(updated, contains('description: Keep this line intact'));
       expect(updated, contains('environment:\n  sdk: ^3.0.0'));
-      expect(updated, contains('version: 0.1.0'));
+      expect(updated, contains('version: 0.0.2'));
     });
 
     test('rolls back pubspec when changelog write fails', () {
@@ -1847,13 +2004,14 @@ environment:
         '{name}/{version}',
         '--commit-types',
         'feat,fix',
+        ..._zeroMajorPolicyCliArgs,
       ]);
 
       expect(options, isNotNull);
-      expect(options!.showHelp, isFalse);
-      expect(options.cwd, 'packages/synthetic_pkg');
-      expect(options.tagFormat, '{name}/{version}');
-      expect(options.commitTypes, 'feat,fix');
+      expect(options!.commitTypes, 'feat,fix');
+      expect(options.policy, isNotNull);
+      expect(options.policy!.major, isEmpty);
+      expect(options.policy!.patch, containsAll({'feat', 'fix'}));
       expect(options.scopes, isNull);
       expect(options.explicitBump, isNull);
       expect(options.explicitVersionText, isNull);
@@ -1868,6 +2026,7 @@ environment:
         '{name}-v{version}',
         '--commit-types',
         'feat,fix',
+        ..._zeroMajorPolicyCliArgs,
         '--scopes',
         'coverde-cli',
       ]);
@@ -1884,6 +2043,7 @@ environment:
         '{name}/{version}',
         '--commit-types',
         'feat,fix',
+        ..._zeroMajorPolicyCliArgs,
         '--bump',
         'patch',
         '--allow-unsafe-bump',
@@ -1903,6 +2063,7 @@ environment:
         '{name}/{version}',
         '--commit-types',
         'feat,fix',
+        ..._zeroMajorPolicyCliArgs,
         '--version',
         '0.0.1-dev.99',
       ]);
@@ -1921,6 +2082,7 @@ environment:
           '{name}/{version}',
           '--commit-types',
           'feat',
+          ..._zeroMajorPolicyCliArgs,
           '--bump',
           'patch',
           '--version',
@@ -1939,6 +2101,7 @@ environment:
           '{name}/{version}',
           '--commit-types',
           'feat',
+          ..._zeroMajorPolicyCliArgs,
           '--bump',
           'invalid',
         ]),
@@ -1954,6 +2117,7 @@ environment:
         '{name}/{version}',
         '--commit-types',
         'feat,fix',
+        ..._zeroMajorPolicyCliArgs,
         '--apply',
       ]);
 
@@ -1970,7 +2134,59 @@ environment:
           '{name}/{version}',
           '--commit-types',
           'feat',
+          ..._zeroMajorPolicyCliArgs,
           '--unknown-flag',
+        ]),
+        isNull,
+      );
+    });
+
+    test('accepts an empty --major-types value', () {
+      final options = parsePrepareReleaseCliOptions([
+        '--cwd',
+        'packages/synthetic_pkg',
+        '--tag-format',
+        '{name}/{version}',
+        '--commit-types',
+        'feat,fix',
+        ..._zeroMajorPolicyCliArgs,
+      ]);
+
+      expect(options, isNotNull);
+      expect(options!.policy!.major, isEmpty);
+    });
+
+    test('rejects missing policy type flags', () {
+      expect(
+        parsePrepareReleaseCliOptions([
+          '--cwd',
+          'packages/synthetic_pkg',
+          '--tag-format',
+          '{name}/{version}',
+          '--commit-types',
+          'feat,fix',
+        ]),
+        isNull,
+      );
+    });
+
+    test('rejects an all-empty auto-bump policy', () {
+      expect(
+        parsePrepareReleaseCliOptions([
+          '--cwd',
+          'packages/synthetic_pkg',
+          '--tag-format',
+          '{name}/{version}',
+          '--commit-types',
+          'feat,fix',
+          '--major-types',
+          '',
+          '--minor-types',
+          '',
+          '--patch-types',
+          '',
+          '--build-types',
+          '',
         ]),
         isNull,
       );
@@ -2008,17 +2224,18 @@ environment:
           '{name}/{version}',
           '--commit-types',
           'feat,fix,docs,refactor,test,build',
+          ..._zeroMajorPolicyCliArgs,
         ],
       );
 
       expect(result.exitCode, 0, reason: result.stderr.toString());
       expect(result.stdout, contains('Dry run'));
       expect(result.stdout, contains('package_name=synthetic_pkg'));
-      expect(result.stdout, contains('release_version=0.1.0'));
+      expect(result.stdout, contains('release_version=0.0.2'));
       expect(result.stdout, contains('latest_tag=synthetic_pkg/0.0.1-dev.2'));
       expect(
         result.stdout,
-        contains('chore(synthetic_pkg): release 0.1.0'),
+        contains('chore(synthetic_pkg): release 0.0.2'),
       );
       expect(
         File('${packageDir.path}/pubspec.yaml').readAsStringSync(),
@@ -2040,6 +2257,10 @@ environment:
       expect(result.stdout, contains('--cwd'));
       expect(result.stdout, contains('--tag-format'));
       expect(result.stdout, contains('--commit-types'));
+      expect(result.stdout, contains('--major-types'));
+      expect(result.stdout, contains('--minor-types'));
+      expect(result.stdout, contains('--patch-types'));
+      expect(result.stdout, contains('--build-types'));
       expect(result.stdout, contains('--scopes'));
       expect(result.stdout, contains('--bump'));
       expect(result.stdout, contains('--version'));
@@ -2054,6 +2275,31 @@ environment:
       );
 
       expect(result.exitCode, 64);
+    });
+
+    test('all-empty policy type flags exit 64', () {
+      final result = _runPrepareReleaseCli(
+        repoRoot: tempRoot,
+        arguments: [
+          '--cwd',
+          'packages/synthetic_pkg',
+          '--tag-format',
+          '{name}/{version}',
+          '--commit-types',
+          'feat,fix',
+          '--major-types',
+          '',
+          '--minor-types',
+          '',
+          '--patch-types',
+          '',
+          '--build-types',
+          '',
+        ],
+      );
+
+      expect(result.exitCode, 64);
+      expect(result.stderr, contains('at least one commit type'));
     });
 
     test('--bump patch produces expected next version in dry-run output', () {
@@ -2086,6 +2332,7 @@ environment:
           '{name}/{version}',
           '--commit-types',
           'feat,fix,docs,refactor,test,build',
+          ..._zeroMajorPolicyCliArgs,
           '--bump',
           'patch',
         ],
@@ -2128,6 +2375,7 @@ environment:
           '{name}/{version}',
           '--commit-types',
           'feat,fix,docs,refactor,test,build',
+          ..._zeroMajorPolicyCliArgs,
           '--version',
           '0.0.1-dev.99',
         ],
@@ -2147,6 +2395,7 @@ environment:
           '{name}/{version}',
           '--commit-types',
           'feat',
+          ..._zeroMajorPolicyCliArgs,
           '--bump',
           'patch',
           '--version',
@@ -2191,6 +2440,7 @@ environment:
           '{name}/{version}',
           '--commit-types',
           'feat,fix,docs,refactor,test,build',
+          ..._zeroMajorPolicyCliArgs,
         ],
       );
       expect(withoutFlag.exitCode, 1);
@@ -2205,12 +2455,13 @@ environment:
           '{name}/{version}',
           '--commit-types',
           'feat,fix,docs,refactor,test,build',
+          ..._zeroMajorPolicyCliArgs,
           '--allow-unsafe-bump',
         ],
       );
 
       expect(withFlag.exitCode, 0, reason: withFlag.stderr.toString());
-      expect(withFlag.stdout, contains('release_version=0.1.0'));
+      expect(withFlag.stdout, contains('release_version=0.0.2'));
     });
 
     test('--apply writes pubspec version and prepends changelog', () {
@@ -2246,21 +2497,22 @@ environment:
           '{name}/{version}',
           '--commit-types',
           'feat,fix,docs,refactor,test,build',
+          ..._zeroMajorPolicyCliArgs,
           '--apply',
         ],
       );
 
       expect(result.exitCode, 0, reason: result.stderr.toString());
       expect(result.stdout, contains('Applied release changes'));
-      expect(result.stdout, contains('release_version=0.1.0'));
+      expect(result.stdout, contains('release_version=0.0.2'));
       expect(
         readPubspecNameAndVersion(File('${packageDir.path}/pubspec.yaml'))
             .version,
-        '0.1.0',
+        '0.0.2',
       );
       expect(
         File('${packageDir.path}/CHANGELOG.md').readAsStringSync(),
-        contains('## 0.1.0'),
+        contains('## 0.0.2'),
       );
       expect(
         File('${tempRoot.path}/README.md').readAsStringSync(),

--- a/tool/prepare_package_release/test/prepare_package_release_test.dart
+++ b/tool/prepare_package_release/test/prepare_package_release_test.dart
@@ -1075,6 +1075,10 @@ issue_tracker: https://github.com/example/clay/issues
         throwsA(isA<UnimplementedError>()),
       );
     });
+
+    test('devRelease factory stays registered in the executable', () {
+      expect(devReleasePolicyFactoryIsRegistered(), isTrue);
+    });
   });
 
   group('computeNextVersion', () {


### PR DESCRIPTION
## Summary
- Adds a required `AutoVersionBumpPolicy` (CLI `--major-types` / `--minor-types` / `--patch-types` / `--build-types`) so auto-bump impact is data, not a hardcoded `major == 0` branch.
- Wires coverde's 0.x map through Melos `release.prepare`: empty major, `feat!`/`fix!` → minor, `feat`/`fix` → patch, other allowed types → build. `devRelease` is stubbed as `UnimplementedError`.
- Updates CONTRIBUTING to document the flags and drops the `coverde-v0.4.1` baseline-tag instruction.

## Test plan
- [x] `dart test tool/prepare_package_release`
- [x] Confirm `melos run release.prepare` still receives the four type-set flags (empty `--major-types` is valid)
- [x] Do not dispatch Prepare until the follow-up `coverde-cli` 0.4.0 restore PR lands