### PR TITLE
chore(coverde-cli): restore 0.4.0 version baseline

### DIFF
--- a/packages/coverde_cli/CHANGELOG.md
+++ b/packages/coverde_cli/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.4.1
-
-- **FEAT**: add wider support for analyzer package v12-v14 (#320).
-
 ## 0.4.0
 
 - **BREAKING FEAT**: require analyzer v11+ (#306).

--- a/packages/coverde_cli/lib/src/utils/package_data.dart
+++ b/packages/coverde_cli/lib/src/utils/package_data.dart
@@ -4,4 +4,4 @@
 const packageName = 'coverde';
 
 /// Package version.
-const packageVersion = '0.4.1';
+const packageVersion = '0.4.0';

--- a/packages/coverde_cli/pubspec.yaml
+++ b/packages/coverde_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: coverde
 description: A CLI for optimizing test execution and manipulating coverage trace files. Optimize tests, validate coverage, filter trace files, and generate HTML reports.
-version: 0.4.1
+version: 0.4.0
 homepage: https://github.com/mrverdant13/coverde
 repository: https://github.com/mrverdant13/coverde/tree/main/packages/coverde_cli
 issue_tracker: https://github.com/mrverdant13/coverde/issues


### PR DESCRIPTION
## Summary
- Restores `packages/coverde_cli` to version `0.4.0` so it matches tag `coverde-v0.4.0`.
- Removes the hand-written `## 0.4.1` changelog section. Does **not** revert #320 analyzer support.
- Regenerated `packageVersion` stays in sync with pubspec.

Depends on #327 landing first. After both merge, dispatch **Prepare Dart package release** to open `coverde/chore/release-0.4.1`.

Do **not** treat this as a release PR (`chore(coverde): release 0.4.0`).

## Test plan
- [x] Confirm pubspec, changelog, and `package_data.dart` all say `0.4.0`
- [x] Merge #327 before dispatching Prepare
- [x] After both PRs are on `main`, run Prepare and expect `0.4.1`