### PR TITLE
ci: install webp for release PR pub score

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -135,6 +135,8 @@ jobs:
           package: melos 7.5.1
       - name: Bootstrap workspace
         run: melos bs
+      - name: Install webp
+        run: sudo apt-get install -y webp
       - name: Run pre-publish gate
         run: melos run release.check
       - name: Set step summary


### PR DESCRIPTION
## Summary
- `release.check` on Dart release PRs runs `pub-score.local`, which needs `webpinfo`/`cwebp` to convert the `coverde` pubspec screenshots.
- Ubuntu runners do not ship those tools, so pana scored documentation 0/10 on #329. Install `webp` before the gate, matching the dedicated local pub-score workflow.

## Test plan
- [x] On the next `chore(coverde): release …` PR, confirm `release.check` installs `webp` and `pub-score.local` reaches 150/150.
- [x] Confirm the job summary has no screenshot conversion errors.