### PR TITLE
ci: install webp for publish pre-publish gate

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -64,6 +64,8 @@ jobs:
           package: melos 7.5.1
       - name: Bootstrap workspace
         run: melos bs
+      - name: Install webp
+        run: sudo apt-get install -y webp
       - name: Run pre-publish gate
         run: melos run release.check
 


### PR DESCRIPTION
## Summary
- The publish workflow `check` job runs `release.check` → `pub-score.local`, which needs `webpinfo`/`cwebp` to convert the `coverde` pubspec screenshots.
- Ubuntu runners do not ship those tools, so the pre-publish gate scored documentation 0/10 on `coverde-v0.4.1`. Install `webp` before the gate, matching the dedicated local pub-score workflow.

## Test plan
- [x] Dispatch **Publish Dart package** with `dry_run: true` from `coverde-v0.4.1` (or `main` after merge) and confirm `Pre-publish checks` reaches 150/150.
- [x] Confirm the log no longer reports `'webpinfo' tool not found`.