### PR TITLE
chore: add ripple.yaml and port Melos scripts

### DIFF
--- a/.cspell/global.allow.txt
+++ b/.cspell/global.allow.txt
@@ -5,6 +5,11 @@ goldens
 lcov
 melos
 mrverdant13
+ripple
+RIPPLE_PACKAGE_NAME
+RIPPLE_PACKAGE_PATH
+RIPPLE_PACKAGES
+RIPPLE_ROOT_PATH
 pubspec
 recase
 termshot

--- a/ripple.yaml
+++ b/ripple.yaml
@@ -1,0 +1,141 @@
+name: coverde
+
+packages:
+  include:
+    - .
+    - packages/*
+    - packages/*/e2e
+    - tools/*
+  exclude:
+    - '**/example/**'
+    - '**/test/fixtures/**'
+    - '**/e2e/fixtures/**'
+    - '**/e2e/e2e/fixtures/**'
+    - tools/prepare_package_release
+    - tools/wait_for_pub_dev_version
+    - tools/readmes_resolver/lib/sample_project
+  groups:
+    e2e:
+      - packages/coverde_cli/e2e
+    publishable:
+      - packages/coverde_cli
+    tools:
+      - tools/package_assets_generator
+      - tools/package_data_generator
+      - tools/pub_score_checker
+      - tools/readmes_resolver
+
+scripts:
+  get:
+    description: Get all packages
+    exec: dart pub get
+
+  format:
+    description: Format a package
+    exec: dart format .
+  format.ci:
+    description: Format all packages (CI)
+    exec: dart format --set-exit-if-changed .
+
+  analyze:
+    description: Analyze a package
+    exec: dart analyze .
+  analyze.ci:
+    description: Analyze all packages (CI)
+    exec: dart analyze --fatal-infos --fatal-warnings .
+
+  gen:
+    description: Run code generation for a package
+    exec: dart run build_runner build --delete-conflicting-outputs
+    filters:
+      - dependsOn: [build_runner]
+
+  spellcheck:
+    description: Run spell checking for the entire project
+    run: cspell lint --config .cspell/cspell.yaml --no-progress ${RIPPLE_ROOT_PATH}/**
+
+  test:
+    description: Run tests and generate coverage trace file for a package
+    exec:
+      - dart run coverde optimize-tests --exclude '**/fixtures/**' --include test/**_test.dart --output test/optimized_test.dart
+      - dart test --color --coverage-path coverage/lcov.info --coverage-package ${RIPPLE_PACKAGE_NAME} --exclude-tags ci-only --reporter expanded --test-randomize-ordering-seed random test/optimized_test.dart
+    filters:
+      - dependsOn: [test]
+      - dirExists: [test]
+  test.ci:
+    description: Run tests for all packages (CI)
+    exec:
+      - dart run coverde optimize-tests --exclude '**/fixtures/**' --include test/**_test.dart --output test/optimized_test.dart
+      - dart test --coverage-path coverage/lcov.info --coverage-package ${RIPPLE_PACKAGE_NAME} --exclude-tags ci-only --reporter expanded --test-randomize-ordering-seed random test/optimized_test.dart
+    filters:
+      - dependsOn: [test]
+      - dirExists: [test]
+
+  coverage.merge:
+    description: Merge all packages coverage trace files
+    run:
+      - dart run coverde rm --no-dry-run ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info
+      - ripple exec --file-exists coverage/lcov.info -- dart run coverde transform --input coverage/lcov.info --output ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info --transformations relative=${RIPPLE_ROOT_PATH} --transformations skip-by-glob='**/*.asset.dart'
+  coverage.check:
+    description: Check test coverage
+    run: dart run coverde check --input ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info 100
+  coverage.report:
+    description: Generate HTML coverage report
+    run: dart run coverde report --input ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info --output ${RIPPLE_ROOT_PATH}/coverage/html/
+
+  test.e2e:
+    description: Run E2E tests
+    exec:
+      - git clean -dfX .
+      - dart test --color --run-skipped --tags e2e e2e
+    filters:
+      - group: e2e
+      - dirExists: [e2e]
+  test.e2e.ci:
+    description: Run E2E tests for all packages (CI)
+    exec:
+      - git clean -dfX .
+      - dart test --run-skipped --tags e2e e2e
+    filters:
+      - group: e2e
+      - dirExists: [e2e]
+
+  pub-score.local:
+    description: Check local pub.dev score for publishable packages
+    exec: dart run pub_score_checker check_pub_score local --markdown-output ${RIPPLE_PACKAGE_PATH}/.dart_tool/local_pub_score.md --package-path ${RIPPLE_PACKAGE_PATH} --threshold 0
+    filters:
+      - group: publishable
+  pub-score.remote:
+    description: Check remote pub.dev score for publishable packages
+    exec: dart run pub_score_checker check_pub_score remote --markdown-output ${RIPPLE_PACKAGE_PATH}/.dart_tool/remote_pub_score.md --package-name ${RIPPLE_PACKAGE_NAME} --threshold 0
+    filters:
+      - group: publishable
+
+  release.prepare:
+    description: >
+      Bump version and changelog for a single package release. Set
+      RIPPLE_PACKAGES=<package> to scope to one package.
+    exec:
+      - dart run ${RIPPLE_ROOT_PATH}/tools/prepare_package_release/prepare_package_release.dart --cwd ${RIPPLE_PACKAGE_PATH} --tag-format '{name}-v{version}' --scopes coverde-cli --commit-types feat,fix,docs,refactor,perf,test,build,chore --major-types= --minor-types feat!,fix! --patch-types feat,fix --build-types docs,refactor,perf,test,build,chore --apply
+      - dart run build_runner build --delete-conflicting-outputs
+    filters:
+      - group: publishable
+
+  # Unscoped full gate. For a single package, run the package-filtered steps with
+  # RIPPLE_PACKAGES=<package> (format.ci / analyze.ci stay repo-wide).
+  release.check:
+    description: Pre-publish gate for all publishable packages
+    run:
+      - ripple run format.ci
+      - ripple run analyze.ci --fail-fast
+      - ripple run test.ci --fail-fast
+      - ripple run pub-score.local --fail-fast
+      - ripple exec --group publishable --fail-fast -- dart pub publish --dry-run
+
+  docs.cli:
+    description: Resolve CLI README file
+    run: dart run ${RIPPLE_ROOT_PATH}/tools/readmes_resolver/lib/resolve_root_readme.dart --example-dirs=${RIPPLE_ROOT_PATH}/packages/coverde_cli/doc/examples/browser/ --example-dirs=${RIPPLE_ROOT_PATH}/packages/coverde_cli/doc/examples/terminal/ --example-dirs=${RIPPLE_ROOT_PATH}/packages/coverde_cli/doc/examples/markdown/ --readme=${RIPPLE_ROOT_PATH}/packages/coverde_cli/README.md
+
+  clean:
+    description: Deep clean-up
+    run: git clean -dfX ${RIPPLE_ROOT_PATH}


### PR DESCRIPTION
## Summary
- Add `ripple.yaml` with Foundry-shaped scripts and Coverde-specific flags (fixture excludes, local `coverde`, E2E `git clean`, `skip-by-glob` for assets).
- Allow Ripple env-var names in the project dictionary so existing Melos CI spellcheck stays green.
- Melos and the Dart workspace are unchanged.

## Test plan
- [x] `ripple list`, `ripple list --group publishable`, and `ripple list --group e2e` match the intended packages
- [x] `melos bs` and `melos run format.ci` still work