### PR TITLE
ci: run workflows with Ripple

### DIFF
--- a/.cspell/ci.allow.txt
+++ b/.cspell/ci.allow.txt
@@ -3,5 +3,6 @@ codecov
 mapfile
 mrverdant13
 pipefail
+ripple
 subosito
 webp

--- a/.github/actions/install-dart-cli/action.yml
+++ b/.github/actions/install-dart-cli/action.yml
@@ -15,29 +15,14 @@ runs:
         PACKAGE_DESCRIPTOR: ${{ inputs.package }}
       run: |
         set -euo pipefail
-        dart install "$PACKAGE_DESCRIPTOR"
+        output="$(dart install "$PACKAGE_DESCRIPTOR")"
+        echo "$output"
 
-        candidates=()
-        if [[ -n "${DART_DATA_HOME:-}" ]]; then
-          candidates+=("${DART_DATA_HOME}/install/bin")
-        fi
-        candidates+=(
-          "${HOME}/Library/Application Support/Dart/install/bin"
-          "${XDG_STATE_HOME:-${HOME}/.local/state}/Dart/install/bin"
-          "${XDG_DATA_HOME:-${HOME}/.local/share}/dart/install/bin"
-        )
-
-        bin_dir=""
-        for dir in "${candidates[@]}"; do
-          if [[ -d "$dir" ]]; then
-            bin_dir="$dir"
-            break
-          fi
-        done
-
-        if [[ -z "$bin_dir" ]]; then
-          echo "::error::dart install bin directory not found after installing ${PACKAGE_DESCRIPTOR}."
+        installed="$(echo "$output" | grep '^Installed:' | sed 's|^Installed: ||')"
+        if [[ -z "$installed" ]]; then
+          echo "::error::dart install did not report an Installed: path for ${PACKAGE_DESCRIPTOR}."
           exit 1
         fi
 
+        bin_dir="$(dirname -- "$installed")"
         echo "$bin_dir" >> "$GITHUB_PATH"

--- a/.github/actions/install-dart-cli/action.yml
+++ b/.github/actions/install-dart-cli/action.yml
@@ -24,5 +24,7 @@ runs:
           exit 1
         fi
 
+        # Git Bash dirname only splits on '/', so normalize Windows separators.
+        installed="${installed//\\//}"
         bin_dir="$(dirname -- "$installed")"
         echo "$bin_dir" >> "$GITHUB_PATH"

--- a/.github/actions/install-dart-cli/action.yml
+++ b/.github/actions/install-dart-cli/action.yml
@@ -2,15 +2,20 @@ name: Install Dart CLI package
 description: Run dart install and add the install bin directory to PATH
 inputs:
   package:
-    description: Package name and optional version constraint (e.g. coverde 0.4.1)
+    description: >-
+      Package descriptor for dart install (e.g. coverde 0.4.1, or a git
+      package descriptor such as
+      ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: <sha>}})
     required: true
 runs:
   using: composite
   steps:
     - shell: bash
+      env:
+        PACKAGE_DESCRIPTOR: ${{ inputs.package }}
       run: |
         set -euo pipefail
-        dart install ${{ inputs.package }}
+        dart install "$PACKAGE_DESCRIPTOR"
 
         candidates=()
         if [[ -n "${DART_DATA_HOME:-}" ]]; then
@@ -31,7 +36,7 @@ runs:
         done
 
         if [[ -z "$bin_dir" ]]; then
-          echo "::error::dart install bin directory not found after installing ${{ inputs.package }}."
+          echo "::error::dart install bin directory not found after installing ${PACKAGE_DESCRIPTOR}."
           exit 1
         fi
 

--- a/.github/actions/install-dart-cli/action.yml
+++ b/.github/actions/install-dart-cli/action.yml
@@ -2,7 +2,7 @@ name: Install Dart CLI package
 description: Run dart install and add the install bin directory to PATH
 inputs:
   package:
-    description: Package name and optional version constraint (e.g. melos 7.5.1)
+    description: Package name and optional version constraint (e.g. coverde 0.4.1)
     required: true
 runs:
   using: composite

--- a/.github/workflows/check_local_pub_score.yaml
+++ b/.github/workflows/check_local_pub_score.yaml
@@ -9,7 +9,7 @@ on:
       - packages/coverde_cli/**
       - tools/pub_score_checker/**
       - .github/workflows/check_local_pub_score.yaml
-      - melos.yaml
+      - ripple.yaml
 
 concurrency:
   cancel-in-progress: true
@@ -24,17 +24,22 @@ jobs:
         uses: actions/checkout@v7
       - name: Install dart
         uses: dart-lang/setup-dart@v1
-      - name: Install melos
-        run: dart pub global activate melos 7.5.1
-      - name: Initialize melos
-        run: melos bs
+      - name: Install ripple
+        uses: ./.github/actions/install-dart-cli
+        with:
+          package: >-
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+      - name: Bootstrap packages
+        run: |
+          dart pub get
+          ripple exec --fail-fast -- dart pub get
       - name: Install dependencies
         run: sudo apt-get install -y webp
       - name: Verify local Pub.dev score
         id: local-pub-score-check
         run: |
           set +e
-          melos run pub-score.local
+          ripple run pub-score.local
           echo "PUB_SCORE_CHECK_RESULT=$?" >> $GITHUB_OUTPUT
       - name: Set step summary
         run: echo "$(cat packages/coverde_cli/.dart_tool/local_pub_score.md)" >>

--- a/.github/workflows/check_remote_pub_score.yaml
+++ b/.github/workflows/check_remote_pub_score.yaml
@@ -18,17 +18,22 @@ jobs:
         uses: actions/checkout@v7
       - name: Install dart
         uses: dart-lang/setup-dart@v1
-      - name: Install melos
-        run: dart pub global activate melos 7.5.1
-      - name: Initialize melos
-        run: melos bs
+      - name: Install ripple
+        uses: ./.github/actions/install-dart-cli
+        with:
+          package: >-
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+      - name: Bootstrap packages
+        run: |
+          dart pub get
+          ripple exec --fail-fast -- dart pub get
       - name: Install dependencies
         run: sudo apt-get install -y webp
       - name: Verify remote Pub.dev score
         id: remote-pub-score-check
         run: |
           set +e
-          melos run pub-score.remote
+          ripple run pub-score.remote
           echo "PUB_SCORE_CHECK_RESULT=$?" >> $GITHUB_OUTPUT
       - name: Set step summary
         run: echo "$(cat packages/coverde_cli/.dart_tool/remote_pub_score.md)" >>

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,12 +24,17 @@ jobs:
           config: ./.cspell/cspell.yaml
       - name: Install dart
         uses: dart-lang/setup-dart@v1
-      - name: Install melos
-        run: dart pub global activate melos 7.5.1
-      - name: Initialize melos
-        run: melos bs
+      - name: Install ripple
+        uses: ./.github/actions/install-dart-cli
+        with:
+          package: >-
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+      - name: Bootstrap packages
+        run: |
+          dart pub get
+          ripple exec --fail-fast -- dart pub get
       - name: Format and analyze
-        run: melos run format.ci && melos run analyze.ci
+        run: ripple run format.ci && ripple run analyze.ci --fail-fast
 
   release-tools:
     name: Test release tools (${{ matrix.package }})
@@ -65,10 +70,15 @@ jobs:
         uses: actions/checkout@v7
       - name: Install dart
         uses: dart-lang/setup-dart@v1
-      - name: Install melos
-        run: dart pub global activate melos 7.5.1
-      - name: Initialize melos
-        run: melos bs
+      - name: Install ripple
+        uses: ./.github/actions/install-dart-cli
+        with:
+          package: >-
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+      - name: Bootstrap packages
+        run: |
+          dart pub get
+          ripple exec --fail-fast -- dart pub get
       - name: Verify up-to-date generated source files
         working-directory: packages/coverde_cli/
         run: dart test --run-skipped -t ci-only test/ensure_up_to_date_src_gen_test.dart
@@ -86,12 +96,17 @@ jobs:
         uses: actions/checkout@v7
       - name: Install dart
         uses: dart-lang/setup-dart@v1
-      - name: Install melos
-        run: dart pub global activate melos 7.5.1
-      - name: Initialize melos
-        run: melos bs
+      - name: Install ripple
+        uses: ./.github/actions/install-dart-cli
+        with:
+          package: >-
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+      - name: Bootstrap packages
+        run: |
+          dart pub get
+          ripple exec --fail-fast -- dart pub get
       - name: Run tests, merge tests if needed, and check 100% coverage
-        run: melos run test.ci && melos run coverage.merge && melos run coverage.check
+        run: ripple run test.ci --fail-fast && ripple run coverage.merge && ripple run coverage.check
       - name: Update coverage trace file as artifact
         uses: actions/upload-artifact@v7
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -23,9 +23,14 @@ jobs:
         uses: actions/checkout@v7
       - name: Install Flutter
         uses: subosito/flutter-action@v2
-      - name: Install melos
-        run: dart pub global activate melos 7.5.1
-      - name: Initialize E2E tests
-        run: melos bs --category=e2e
+      - name: Install ripple
+        uses: ./.github/actions/install-dart-cli
+        with:
+          package: >-
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+      - name: Bootstrap packages
+        run: |
+          dart pub get
+          ripple exec --fail-fast -- dart pub get
       - name: Run E2E tests
-        run: melos run test.e2e.all
+        run: ripple run test.e2e.ci --fail-fast

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -1,5 +1,5 @@
 # Opens a version-bump release PR for coverde via workflow_dispatch.
-# Runs melos release.prepare, pushes coverde/chore/release-<version>, and opens a PR.
+# Runs ripple release.prepare, pushes coverde/chore/release-<version>, and opens a PR.
 # Does not publish to pub.dev or create git tags.
 name: Prepare Dart package release
 
@@ -37,13 +37,16 @@ jobs:
       - name: Install Dart
         uses: dart-lang/setup-dart@v1
 
-      - name: Install melos
+      - name: Install ripple
         uses: ./.github/actions/install-dart-cli
         with:
-          package: melos 7.5.1
+          package: >-
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
 
-      - name: Bootstrap workspace
-        run: melos bs
+      - name: Bootstrap packages
+        run: |
+          dart pub get
+          ripple exec --fail-fast -- dart pub get
 
       - name: Configure git author
         run: |
@@ -51,7 +54,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Bump version and changelog
-        run: MELOS_PACKAGES=${{ inputs.package }} melos run release.prepare
+        run: RIPPLE_PACKAGES=${{ inputs.package }} ripple run release.prepare
 
       - name: Read release version
         id: version
@@ -104,7 +107,7 @@ jobs:
 
           Automated version bump for \`${package}\` via the **Prepare Dart package release** workflow.
 
-          - Entry point: \`MELOS_PACKAGES=${package} melos run release.prepare\`
+          - Entry point: \`RIPPLE_PACKAGES=${package} ripple run release.prepare\`
           - Version bump: \`tools/prepare_package_release/prepare_package_release.dart\` auto-bump from scoped conventional commits
           - Changelog: commits scoped \`coverde-cli\` since the latest \`coverde-v<version>\` tag
           EOF

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,7 +7,7 @@
 #    OIDC auth succeeds on tag refs; publish runs and pub.dev is polled.
 #    On failure, the release tag is deleted so unpublished versions are not permanently tagged.
 #
-# dry_run: true (default) runs release.check only — dispatch from main or a tag ref.
+# dry_run: true (default) runs the pre-publish gate only — dispatch from main or a tag ref.
 # dry_run: false publishes via OIDC — must dispatch on the matching release tag ref.
 name: Publish Dart package
 
@@ -21,7 +21,7 @@ on:
         options:
           - coverde
       dry_run:
-        description: Pre-publish gate only via release.check (no pub.dev publish)
+        description: Pre-publish gate only (no pub.dev publish)
         required: true
         type: boolean
         default: true
@@ -35,7 +35,7 @@ jobs:
     name: Pre-publish checks (${{ inputs.package }})
     runs-on: ubuntu-latest
     env:
-      MELOS_PACKAGES: ${{ inputs.package }}
+      RIPPLE_PACKAGES: ${{ inputs.package }}
       PACKAGE_DIR: packages/coverde_cli
     steps:
       - name: Check out repository
@@ -58,16 +58,26 @@ jobs:
           fi
       - name: Install Dart
         uses: dart-lang/setup-dart@v1
-      - name: Install melos
+      - name: Install ripple
         uses: ./.github/actions/install-dart-cli
         with:
-          package: melos 7.5.1
-      - name: Bootstrap workspace
-        run: melos bs
+          package: >-
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+      - name: Bootstrap packages
+        run: |
+          dart pub get
+          ripple exec --fail-fast -- dart pub get
       - name: Install webp
         run: sudo apt-get install -y webp
-      - name: Run pre-publish gate
-        run: melos run release.check
+      - name: Format and analyze
+        run: |
+          ripple run format.ci
+          ripple run analyze.ci --fail-fast
+      - name: Run package-scoped pre-publish checks
+        run: |
+          ripple run test.ci --fail-fast
+          ripple run pub-score.local --fail-fast
+          ripple exec --group publishable --fail-fast -- dart pub publish --dry-run
 
   publish:
     name: Publish (${{ inputs.package }})
@@ -102,12 +112,15 @@ jobs:
           fi
       - name: Install Dart
         uses: dart-lang/setup-dart@v1
-      - name: Install melos
+      - name: Install ripple
         uses: ./.github/actions/install-dart-cli
         with:
-          package: melos 7.5.1
-      - name: Bootstrap workspace
-        run: melos bs
+          package: >-
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+      - name: Bootstrap packages
+        run: |
+          dart pub get
+          ripple exec --fail-fast -- dart pub get
       - name: Verify release tag on HEAD
         env:
           PACKAGE: ${{ inputs.package }}

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -1,4 +1,4 @@
-# Runs MELOS_PACKAGES-scoped release.check on Dart package release pull requests.
+# Runs RIPPLE_PACKAGES-scoped pre-publish checks on Dart package release pull requests.
 name: Dart release PR check
 
 on:
@@ -46,12 +46,15 @@ jobs:
           fetch-depth: 0
       - name: Install Dart
         uses: dart-lang/setup-dart@v1
-      - name: Install melos
+      - name: Install ripple
         uses: ./.github/actions/install-dart-cli
         with:
-          package: melos 7.5.1
-      - name: Bootstrap workspace
-        run: melos bs
+          package: >-
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+      - name: Bootstrap packages
+        run: |
+          dart pub get
+          ripple exec --fail-fast -- dart pub get
       - name: Verify release manifest changes match title
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -68,20 +71,12 @@ jobs:
             exit 1
           fi
 
-          mapfile -t publishable_packages < <(melos list --category=publishable)
-
           is_publishable() {
-            local candidate="$1"
-            for package in "${publishable_packages[@]}"; do
-              if [[ "$package" == "$candidate" ]]; then
-                return 0
-              fi
-            done
-            return 1
+            [[ -n "$(ripple list --group publishable --match "$1")" ]]
           }
 
           if ! is_publishable "$TITLE_PACKAGE"; then
-            echo "::error::Unknown publishable package '$TITLE_PACKAGE'. Expected one of: ${publishable_packages[*]}"
+            echo "::error::Unknown publishable package '$TITLE_PACKAGE'."
             exit 1
           fi
 
@@ -122,28 +117,40 @@ jobs:
       - resolve-package
     if: needs.parse-title.outputs.matched == 'true'
     runs-on: ubuntu-latest
-    env:
-      MELOS_PACKAGES: ${{ needs.parse-title.outputs.package }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
       - name: Install Dart
         uses: dart-lang/setup-dart@v1
-      - name: Install melos
+      - name: Install ripple
         uses: ./.github/actions/install-dart-cli
         with:
-          package: melos 7.5.1
-      - name: Bootstrap workspace
-        run: melos bs
+          package: >-
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+      - name: Bootstrap packages
+        run: |
+          dart pub get
+          ripple exec --fail-fast -- dart pub get
       - name: Install webp
         run: sudo apt-get install -y webp
-      - name: Run pre-publish gate
-        run: melos run release.check
+      - name: Format and analyze
+        run: |
+          ripple run format.ci
+          ripple run analyze.ci --fail-fast
+      - name: Run package-scoped pre-publish checks
+        env:
+          RIPPLE_PACKAGES: ${{ needs.parse-title.outputs.package }}
+        run: |
+          ripple run test.ci --fail-fast
+          ripple run pub-score.local --fail-fast
+          ripple exec --group publishable --fail-fast -- dart pub publish --dry-run
       - name: Set step summary
         if: always()
+        env:
+          PACKAGE: ${{ needs.parse-title.outputs.package }}
         run: |
           report="packages/coverde_cli/.dart_tool/local_pub_score.md"
           if [[ -f "$report" ]]; then
-            echo "### ${MELOS_PACKAGES}" >> "$GITHUB_STEP_SUMMARY"
+            echo "### ${PACKAGE}" >> "$GITHUB_STEP_SUMMARY"
             cat "$report" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/resolve_readmes.yaml
+++ b/.github/workflows/resolve_readmes.yaml
@@ -8,7 +8,7 @@ on:
     paths:
       - .github/workflows/resolve_readmes.yaml
       - packages/coverde_cli/**
-      - melos.yaml
+      - ripple.yaml
       - README.md
       - tools/readmes_resolver/**
 
@@ -21,12 +21,17 @@ jobs:
         uses: actions/checkout@v7
       - name: Install dart
         uses: dart-lang/setup-dart@v1
-      - name: Install melos
-        run: dart pub global activate melos 7.5.1
-      - name: Initialize READMEs resolver
-        run: melos bs --scope=readmes_resolver
+      - name: Install ripple
+        uses: ./.github/actions/install-dart-cli
+        with:
+          package: >-
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+      - name: Bootstrap packages
+        run: |
+          dart pub get
+          ripple exec --fail-fast -- dart pub get
       - name: Resolve CLI README file
-        run: melos run docs.cli
+        run: ripple run docs.cli
       - name: Create PR
         uses: peter-evans/create-pull-request@v8
         with:


### PR DESCRIPTION
## Summary
- Install Ripple via `install-dart-cli` and bootstrap with `dart pub get` plus `ripple exec --fail-fast -- dart pub get`.
- Replace Melos script invocations in CI, E2E, release, publish, README, and pub-score workflows.
- Keep Flutter E2E, `src-gen`, `release-tools`, and the `packages/coverde_cli` → `coverde` publishable mapping.
- Inline scoped pre-publish steps because Ripple `run:` scripts reject `RIPPLE_PACKAGES`.

## Test plan
- [x] Dart CI format/analyze and test jobs run Ripple commands
- [x] Release PR check still maps `packages/coverde_cli` to package name `coverde`
- [x] Local `melos` commands still work while the workspace remains