### PR TITLE
ci: resolve pub_score_checker after workspace drop

### DIFF
--- a/.github/workflows/check_local_pub_score.yaml
+++ b/.github/workflows/check_local_pub_score.yaml
@@ -42,10 +42,21 @@ jobs:
           ripple run pub-score.local
           echo "PUB_SCORE_CHECK_RESULT=$?" >> $GITHUB_OUTPUT
       - name: Set step summary
-        run: echo "$(cat packages/coverde_cli/.dart_tool/local_pub_score.md)" >>
-          $GITHUB_STEP_SUMMARY
+        if: always()
+        run: |
+          report="packages/coverde_cli/.dart_tool/local_pub_score.md"
+          if [[ -f "$report" ]]; then
+            cat "$report" >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Create or update issue
         run: |
+          set -euo pipefail
+          result="${{ steps.local-pub-score-check.outputs.PUB_SCORE_CHECK_RESULT }}"
+          report="${{ env.ISSUE_BODY_FILEPATH }}"
+          if [[ "$result" != "0" && ! -f "$report" ]]; then
+            echo "::error::pub-score checker failed without writing a report (exit $result)"
+            exit 1
+          fi
           issueNumber=$(\
             gh issue list \
               --search "${{ env.ISSUE_SEARCH_TERM }}" \
@@ -54,7 +65,7 @@ jobs:
               --json number \
               --jq '.[0].number // empty'
             )
-          if [[ "${{ steps.local-pub-score-check.outputs.PUB_SCORE_CHECK_RESULT }}" == "0" ]]; then
+          if [[ "$result" == "0" ]]; then
             if [[ -n $issueNumber ]]; then
               echo "Issue already exists: $issueNumber"
               gh issue close $issueNumber --comment "Local Pub.dev score is valid"
@@ -63,12 +74,12 @@ jobs:
             if [[ -n $issueNumber ]]; then
               echo "Issue already exists: $issueNumber"
               gh issue edit $issueNumber \
-                --body-file "${{ env.ISSUE_BODY_FILEPATH }}"
+                --body-file "$report"
             else
               echo "Issue does not exist"
               gh issue create \
                 --title "${{ env.ISSUE_TITLE }}" \
-                --body-file "${{ env.ISSUE_BODY_FILEPATH }}" \
+                --body-file "$report" \
                 --label "triage" \
                 --label "p:coverde" \
                 --assignee "mrverdant13"

--- a/.github/workflows/check_remote_pub_score.yaml
+++ b/.github/workflows/check_remote_pub_score.yaml
@@ -36,10 +36,21 @@ jobs:
           ripple run pub-score.remote
           echo "PUB_SCORE_CHECK_RESULT=$?" >> $GITHUB_OUTPUT
       - name: Set step summary
-        run: echo "$(cat packages/coverde_cli/.dart_tool/remote_pub_score.md)" >>
-          $GITHUB_STEP_SUMMARY
+        if: always()
+        run: |
+          report="packages/coverde_cli/.dart_tool/remote_pub_score.md"
+          if [[ -f "$report" ]]; then
+            cat "$report" >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Create or update issue
         run: |
+          set -euo pipefail
+          result="${{ steps.remote-pub-score-check.outputs.PUB_SCORE_CHECK_RESULT }}"
+          report="${{ env.ISSUE_BODY_FILEPATH }}"
+          if [[ "$result" != "0" && ! -f "$report" ]]; then
+            echo "::error::pub-score checker failed without writing a report (exit $result)"
+            exit 1
+          fi
           issueNumber=$(\
             gh issue list \
               --search "${{ env.ISSUE_SEARCH_TERM }}" \
@@ -48,7 +59,7 @@ jobs:
               --json number \
               --jq '.[0].number // empty'
             )
-          if [[ "${{ steps.remote-pub-score-check.outputs.PUB_SCORE_CHECK_RESULT }}" == "0" ]]; then
+          if [[ "$result" == "0" ]]; then
             if [[ -n $issueNumber ]]; then
               echo "Issue already exists: $issueNumber"
               gh issue close $issueNumber --comment "Remote Pub.dev score is valid"
@@ -57,12 +68,12 @@ jobs:
             if [[ -n $issueNumber ]]; then
               echo "Issue already exists: $issueNumber"
               gh issue edit $issueNumber \
-                --body-file "${{ env.ISSUE_BODY_FILEPATH }}"
+                --body-file "$report"
             else
               echo "Issue does not exist"
               gh issue create \
                 --title "${{ env.ISSUE_TITLE }}" \
-                --body-file "${{ env.ISSUE_BODY_FILEPATH }}" \
+                --body-file "$report" \
                 --label "triage" \
                 --label "p:coverde" \
                 --assignee "mrverdant13"

--- a/ripple.yaml
+++ b/ripple.yaml
@@ -102,12 +102,12 @@ scripts:
 
   pub-score.local:
     description: Check local pub.dev score for publishable packages
-    exec: dart run pub_score_checker check_pub_score local --markdown-output ${RIPPLE_PACKAGE_PATH}/.dart_tool/local_pub_score.md --package-path ${RIPPLE_PACKAGE_PATH} --threshold 0
+    exec: dart run ${RIPPLE_ROOT_PATH}/tools/pub_score_checker/bin/pub_score_checker.dart check_pub_score local --markdown-output ${RIPPLE_PACKAGE_PATH}/.dart_tool/local_pub_score.md --package-path ${RIPPLE_PACKAGE_PATH} --threshold 0
     filters:
       - group: publishable
   pub-score.remote:
     description: Check remote pub.dev score for publishable packages
-    exec: dart run pub_score_checker check_pub_score remote --markdown-output ${RIPPLE_PACKAGE_PATH}/.dart_tool/remote_pub_score.md --package-name ${RIPPLE_PACKAGE_NAME} --threshold 0
+    exec: dart run ${RIPPLE_ROOT_PATH}/tools/pub_score_checker/bin/pub_score_checker.dart check_pub_score remote --markdown-output ${RIPPLE_PACKAGE_PATH}/.dart_tool/remote_pub_score.md --package-name ${RIPPLE_PACKAGE_NAME} --threshold 0
     filters:
       - group: publishable
 


### PR DESCRIPTION
## Summary
- Run `pub-score.local` / `pub-score.remote` via `tools/pub_score_checker/bin/pub_score_checker.dart` so Ripple `exec` still resolves the tool after the Dart pub workspace was dropped.
- Guard local/remote pub-score workflows: only attach a step summary when the report exists, and fail instead of `gh issue edit --body-file` when the checker crashes with no report.

Fixes #288 once the remote workflow can actually run and the published score is still 150/150 (it will close the issue). The last red run on `main` was exit 255 plus a missing `remote_pub_score.md`.

## Test plan
- [x] `ripple run analyze.ci --fail-fast`
- [x] `ripple run pub-score.local` (150/150)
- [x] `ripple run pub-score.remote` (150/150)
- [ ] After merge, re-dispatch **Check remote Pub.dev score for Coverde CLI** on `main` and confirm it is not 255 and does not fail on a missing body file