### PR TITLE
chore: update ripple.yaml

### DIFF
--- a/ripple.yaml
+++ b/ripple.yaml
@@ -102,12 +102,12 @@ scripts:
 
   pub-score.local:
     description: Check local pub.dev score for publishable packages
-    exec: dart run pub_score_checker check_pub_score local --markdown-output ${RIPPLE_PACKAGE_PATH}/.dart_tool/local_pub_score.md --package-path ${RIPPLE_PACKAGE_PATH} --threshold 0
+    exec: dart run ${RIPPLE_ROOT_PATH}/tools/pub_score_checker/bin/pub_score_checker.dart check_pub_score local --markdown-output ${RIPPLE_PACKAGE_PATH}/.dart_tool/local_pub_score.md --package-path ${RIPPLE_PACKAGE_PATH} --threshold 0
     filters:
       - group: publishable
   pub-score.remote:
     description: Check remote pub.dev score for publishable packages
-    exec: dart run pub_score_checker check_pub_score remote --markdown-output ${RIPPLE_PACKAGE_PATH}/.dart_tool/remote_pub_score.md --package-name ${RIPPLE_PACKAGE_NAME} --threshold 0
+    exec: dart run ${RIPPLE_ROOT_PATH}/tools/pub_score_checker/bin/pub_score_checker.dart check_pub_score remote --markdown-output ${RIPPLE_PACKAGE_PATH}/.dart_tool/remote_pub_score.md --package-name ${RIPPLE_PACKAGE_NAME} --threshold 0
     filters:
       - group: publishable
 


### PR DESCRIPTION
## Summary
- Point `pub-score.local` and `pub-score.remote` at `tools/pub_score_checker/bin/pub_score_checker.dart` so Ripple `exec` still resolves the tool after the Dart pub workspace was dropped.

This is the actual checker-resolution fix. After merge, `ripple run pub-score.remote` on `main` should no longer exit 255.

Related: #288

## Test plan
- [x] `ripple run pub-score.local` resolves the tool (not “Could not find package pub_score_checker”)
- [x] `ripple run pub-score.remote` resolves the tool the same way