### PR TITLE
ci: publish Codecov coverage only from main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,12 @@ jobs:
   min-conditions:
     name: Check spelling, format and analyze codebase
     runs-on: ubuntu-latest
+    outputs:
+      publish_coverage: ${{ steps.coverage-publish.outputs.publish }}
     steps:
+      - name: Resolve whether to publish coverage
+        id: coverage-publish
+        run: echo "publish=${{ github.event_name != 'pull_request' && secrets.CODECOV_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
       - name: Check out repository
         uses: actions/checkout@v7
       - name: Check spelling
@@ -117,19 +122,22 @@ jobs:
 
   codecov:
     name: Publish coverage results
-    needs: test
+    needs:
+      - min-conditions
+      - test
+    if: needs.min-conditions.outputs.publish_coverage == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Download coverage trace file artifacts
         uses: actions/download-artifact@v8
         with:
           name: filtered.lcov.info
+          path: coverage
       - name: Upload coverage data to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           disable_search: true
-          directory: ./coverage/
-          files: ./filtered.lcov.info
+          files: coverage/filtered.lcov.info
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Resolve whether to publish coverage
         id: coverage-publish
-        run: echo "publish=${{ github.event_name != 'pull_request' && secrets.CODECOV_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
+        run: echo "publish=${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}" >> "$GITHUB_OUTPUT"
       - name: Check out repository
         uses: actions/checkout@v7
       - name: Check spelling


### PR DESCRIPTION
## Summary
- Upgrade `codecov/codecov-action` from v6 to v7.
- Publish coverage only on push to `main` or `workflow_dispatch` when `CODECOV_TOKEN` is set; skip the job on pull requests (Dependabot PRs were failing with an empty token).
- Download the coverage artifact into `coverage/` so the upload path matches.

Supersedes #313.

## Test plan
- [x] On this PR, Dart CI skips **Publish coverage results** (does not fail).
- [x] After merge, a push to `main` runs the Codecov upload successfully.
- [x] Confirm **Publish coverage results** is not a required status check on `main`.