### PR TITLE
ci: label PRs by conventional type and package

### DIFF
--- a/.cspell/ci.allow.txt
+++ b/.cspell/ci.allow.txt
@@ -1,5 +1,6 @@
 # Allowed words for CI files
 codecov
+labeler
 mapfile
 mrverdant13
 pipefail

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,7 +5,8 @@ updates:
     directory: /
     schedule:
       interval: daily
-    labels: []
+    labels:
+      - ci
     commit-message:
       prefix: ci
 
@@ -13,7 +14,9 @@ updates:
     directory: /tools/package_assets_generator
     schedule:
       interval: daily
-    labels: []
+    labels:
+      - chore
+      - t:package-assets-generator
     versioning-strategy: increase
     commit-message:
       prefix: "chore(t-package-assets-generator)"
@@ -22,7 +25,9 @@ updates:
     directory: /tools/package_data_generator
     schedule:
       interval: daily
-    labels: []
+    labels:
+      - chore
+      - t:package-data-generator
     versioning-strategy: increase
     commit-message:
       prefix: "chore(t-package-data-generator)"
@@ -31,7 +36,9 @@ updates:
     directory: /tools/prepare_package_release
     schedule:
       interval: daily
-    labels: []
+    labels:
+      - chore
+      - t:prepare-package-release
     versioning-strategy: increase
     commit-message:
       prefix: "chore(t-prepare-package-release)"
@@ -40,7 +47,9 @@ updates:
     directory: /tools/pub_score_checker
     schedule:
       interval: daily
-    labels: []
+    labels:
+      - chore
+      - t:pub-score-checker
     versioning-strategy: increase
     commit-message:
       prefix: "chore(t-pub-score-checker)"
@@ -49,7 +58,9 @@ updates:
     directory: /tools/readmes_resolver
     schedule:
       interval: daily
-    labels: []
+    labels:
+      - chore
+      - t:readmes-resolver
     versioning-strategy: increase
     commit-message:
       prefix: "chore(t-readmes-resolver)"
@@ -58,7 +69,9 @@ updates:
     directory: /tools/wait_for_pub_dev_version
     schedule:
       interval: daily
-    labels: []
+    labels:
+      - chore
+      - t:wait-for-pub-dev-version
     versioning-strategy: increase
     commit-message:
       prefix: "chore(t-wait-for-pub-dev-version)"
@@ -67,7 +80,9 @@ updates:
     directory: /packages/coverde_cli/e2e
     schedule:
       interval: daily
-    labels: []
+    labels:
+      - test
+      - p:coverde
     versioning-strategy: increase
     commit-message:
       prefix: "test(coverde-cli)"

--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,0 +1,106 @@
+# Package and tool labels from changed files or conventional branch scopes.
+"p:coverde":
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/coverde_cli/**
+  - head-branch:
+      - (^|/)coverde-cli(/|$)
+      - ^coverde(/|$)
+
+"t:package-assets-generator":
+  - changed-files:
+      - any-glob-to-any-file:
+          - tools/package_assets_generator/**
+  - head-branch:
+      - (^|/)t-package-assets-generator(/|$)
+
+"t:package-data-generator":
+  - changed-files:
+      - any-glob-to-any-file:
+          - tools/package_data_generator/**
+  - head-branch:
+      - (^|/)t-package-data-generator(/|$)
+
+"t:pub-score-checker":
+  - changed-files:
+      - any-glob-to-any-file:
+          - tools/pub_score_checker/**
+  - head-branch:
+      - (^|/)t-pub-score-checker(/|$)
+
+"t:readmes-resolver":
+  - changed-files:
+      - any-glob-to-any-file:
+          - tools/readmes_resolver/**
+  - head-branch:
+      - (^|/)t-readmes-resolver(/|$)
+
+"t:prepare-package-release":
+  - changed-files:
+      - any-glob-to-any-file:
+          - tools/prepare_package_release/**
+  - head-branch:
+      - (^|/)t-prepare-package-release(/|$)
+
+"t:wait-for-pub-dev-version":
+  - changed-files:
+      - any-glob-to-any-file:
+          - tools/wait_for_pub_dev_version/**
+  - head-branch:
+      - (^|/)t-wait-for-pub-dev-version(/|$)
+
+# Type labels from conventional branch names, paths, or Dependabot ecosystems.
+feature:
+  - head-branch:
+      - (^|/)feat(/|$)
+      - (^|/)feature(/|$)
+
+fix:
+  - head-branch:
+      - (^|/)fix(/|$)
+
+refactor:
+  - head-branch:
+      - (^|/)refactor(/|$)
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/CHANGELOG.md"
+          - "**/README.md"
+          - CONTRIBUTING.md
+          - doc/**
+  - head-branch:
+      - (^|/)docs(/|$)
+
+test:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/test/**"
+          - "**/e2e/**"
+          - "**/*_test.dart"
+  - head-branch:
+      - (^|/)test(/|$)
+      - ^dependabot/pub/packages/coverde_cli/e2e/.+
+
+chore:
+  - head-branch:
+      - (^|/)chore(/|$)
+      - ^dependabot/pub/tools/.+
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/**
+  - head-branch:
+      - (^|/)ci(/|$)
+      - ^dependabot/github_actions/.+
+
+build:
+  - head-branch:
+      - (^|/)build(/|$)
+
+performance:
+  - head-branch:
+      - (^|/)perf(/|$)
+      - (^|/)performance(/|$)

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,22 @@
+# Applies type and package labels from .github/labeler.yaml.
+# pull_request_target runs on the base branch so the config is trusted.
+name: Pull Request Labeler
+
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+      - name: Label pull request
+        uses: actions/labeler@v7
+        with:
+          configuration-path: .github/labeler.yaml
+          sync-labels: true


### PR DESCRIPTION
## Summary
- Apply conventional type and package/tool labels from Dependabot (`ci`, `chore` + `t:…`, `test` + `p:coverde`) so new PRs match CONTRIBUTING scopes.
- Add `actions/labeler` on `pull_request_target` (Foundry-style) to set the same labels from changed files and branch names.
- Drop Dependabot-only labels (`dependencies`, `dart`, `github_actions`); tool packages use `t:*` (`p:coverde` stays for the publishable CLI).

## Test plan
- [x] Confirm this PR is labeled `ci` (add manually if needed; labeler runs from `main` after merge).
- [x] After merge, open or push to a Dependabot tool PR and confirm `chore` + the matching `t:*` label.
- [x] After merge, open or push to a Dependabot Actions PR and confirm only `ci`.
- [x] After merge, a `feat/…` branch that touches `packages/coverde_cli/**` gets `feature` + `p:coverde`.