### PR TITLE
chore: exclude packages and tools from root analysis

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
 analyzer:
   exclude:
-    - tools/prepare_package_release/**
-    - tools/wait_for_pub_dev_version/**
+    - packages/**
+    - tools/**


### PR DESCRIPTION
## Summary
- Exclude `packages/**` and `tools/**` from the root analyzer so nested packages are linted only through their own `analysis_options.yaml`.
- Keeps this change scoped to repo-root analysis config, without mixing package source updates.

## Test plan
- [x] Root `dart analyze .` reports no issues
- [x] CI `format.ci` and `analyze.ci` still pass (Ripple analyzes each package separately)