### PR TITLE
ci: pin Ripple and wrap dart invocations with {{dart}}

### DIFF
--- a/.cspell/docs.allow.txt
+++ b/.cspell/docs.allow.txt
@@ -1,5 +1,6 @@
 # Allowed words for documentation files
 codecov
+fvm
 Karlo
 ripple
 runbook

--- a/.cspell/docs.allow.txt
+++ b/.cspell/docs.allow.txt
@@ -2,5 +2,6 @@
 codecov
 fvm
 Karlo
+powershell
 ripple
 runbook

--- a/.github/workflows/check_local_pub_score.yaml
+++ b/.github/workflows/check_local_pub_score.yaml
@@ -30,7 +30,7 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: ripple run get.ci --fail-fast
+        run: ripple run get --fail-fast
       - name: Install dependencies
         run: sudo apt-get install -y webp
       - name: Verify local Pub.dev score

--- a/.github/workflows/check_local_pub_score.yaml
+++ b/.github/workflows/check_local_pub_score.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- {{dart}} pub get
+          ripple exec --fail-fast -- "{{dart}}" pub get
       - name: Install dependencies
         run: sudo apt-get install -y webp
       - name: Verify local Pub.dev score

--- a/.github/workflows/check_local_pub_score.yaml
+++ b/.github/workflows/check_local_pub_score.yaml
@@ -28,11 +28,11 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- "{{dart}}" pub get
+          ripple exec --fail-fast -- '{{dart}}' pub get
       - name: Install dependencies
         run: sudo apt-get install -y webp
       - name: Verify local Pub.dev score

--- a/.github/workflows/check_local_pub_score.yaml
+++ b/.github/workflows/check_local_pub_score.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
       - name: Bootstrap packages
         run: |
           dart pub get

--- a/.github/workflows/check_local_pub_score.yaml
+++ b/.github/workflows/check_local_pub_score.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- dart pub get
+          ripple exec --fail-fast -- {{dart}} pub get
       - name: Install dependencies
         run: sudo apt-get install -y webp
       - name: Verify local Pub.dev score

--- a/.github/workflows/check_local_pub_score.yaml
+++ b/.github/workflows/check_local_pub_score.yaml
@@ -30,9 +30,7 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: |
-          dart pub get
-          ripple exec --fail-fast -- '{{dart}}' pub get
+        run: ripple run get.ci --fail-fast
       - name: Install dependencies
         run: sudo apt-get install -y webp
       - name: Verify local Pub.dev score

--- a/.github/workflows/check_local_pub_score.yaml
+++ b/.github/workflows/check_local_pub_score.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
       - name: Bootstrap packages
         run: |
           dart pub get

--- a/.github/workflows/check_remote_pub_score.yaml
+++ b/.github/workflows/check_remote_pub_score.yaml
@@ -24,7 +24,7 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: ripple run get.ci --fail-fast
+        run: ripple run get --fail-fast
       - name: Install dependencies
         run: sudo apt-get install -y webp
       - name: Verify remote Pub.dev score

--- a/.github/workflows/check_remote_pub_score.yaml
+++ b/.github/workflows/check_remote_pub_score.yaml
@@ -22,11 +22,11 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- "{{dart}}" pub get
+          ripple exec --fail-fast -- '{{dart}}' pub get
       - name: Install dependencies
         run: sudo apt-get install -y webp
       - name: Verify remote Pub.dev score

--- a/.github/workflows/check_remote_pub_score.yaml
+++ b/.github/workflows/check_remote_pub_score.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
       - name: Bootstrap packages
         run: |
           dart pub get

--- a/.github/workflows/check_remote_pub_score.yaml
+++ b/.github/workflows/check_remote_pub_score.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- dart pub get
+          ripple exec --fail-fast -- {{dart}} pub get
       - name: Install dependencies
         run: sudo apt-get install -y webp
       - name: Verify remote Pub.dev score

--- a/.github/workflows/check_remote_pub_score.yaml
+++ b/.github/workflows/check_remote_pub_score.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
       - name: Bootstrap packages
         run: |
           dart pub get

--- a/.github/workflows/check_remote_pub_score.yaml
+++ b/.github/workflows/check_remote_pub_score.yaml
@@ -24,9 +24,7 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: |
-          dart pub get
-          ripple exec --fail-fast -- '{{dart}}' pub get
+        run: ripple run get.ci --fail-fast
       - name: Install dependencies
         run: sudo apt-get install -y webp
       - name: Verify remote Pub.dev score

--- a/.github/workflows/check_remote_pub_score.yaml
+++ b/.github/workflows/check_remote_pub_score.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- {{dart}} pub get
+          ripple exec --fail-fast -- "{{dart}}" pub get
       - name: Install dependencies
         run: sudo apt-get install -y webp
       - name: Verify remote Pub.dev score

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,11 +33,11 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- "{{dart}}" pub get
+          ripple exec --fail-fast -- '{{dart}}' pub get
       - name: Format and analyze
         run: ripple run format.ci && ripple run analyze.ci --fail-fast
 
@@ -79,11 +79,11 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- "{{dart}}" pub get
+          ripple exec --fail-fast -- '{{dart}}' pub get
       - name: Verify up-to-date generated source files
         working-directory: packages/coverde_cli/
         run: dart test --run-skipped -t ci-only test/ensure_up_to_date_src_gen_test.dart
@@ -105,11 +105,11 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- "{{dart}}" pub get
+          ripple exec --fail-fast -- '{{dart}}' pub get
       - name: Run tests, merge tests if needed, and check 100% coverage
         run: ripple run test.ci --fail-fast && ripple run coverage.merge && ripple run coverage.check
       - name: Update coverage trace file as artifact

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,9 +35,7 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: |
-          dart pub get
-          ripple exec --fail-fast -- '{{dart}}' pub get
+        run: ripple run get.ci --fail-fast
       - name: Format and analyze
         run: ripple run format.ci && ripple run analyze.ci --fail-fast
 
@@ -81,9 +79,7 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: |
-          dart pub get
-          ripple exec --fail-fast -- '{{dart}}' pub get
+        run: ripple run get.ci --fail-fast
       - name: Verify up-to-date generated source files
         working-directory: packages/coverde_cli/
         run: dart test --run-skipped -t ci-only test/ensure_up_to_date_src_gen_test.dart
@@ -107,9 +103,7 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: |
-          dart pub get
-          ripple exec --fail-fast -- '{{dart}}' pub get
+        run: ripple run get.ci --fail-fast
       - name: Run tests, merge tests if needed, and check 100% coverage
         run: ripple run test.ci --fail-fast && ripple run coverage.merge && ripple run coverage.check
       - name: Update coverage trace file as artifact

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: ripple run get.ci --fail-fast
+        run: ripple run get --fail-fast
       - name: Format and analyze
         run: ripple run format.ci && ripple run analyze.ci --fail-fast
 
@@ -79,7 +79,7 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: ripple run get.ci --fail-fast
+        run: ripple run get --fail-fast
       - name: Verify up-to-date generated source files
         working-directory: packages/coverde_cli/
         run: dart test --run-skipped -t ci-only test/ensure_up_to_date_src_gen_test.dart
@@ -103,7 +103,7 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: ripple run get.ci --fail-fast
+        run: ripple run get --fail-fast
       - name: Run tests, merge tests if needed, and check 100% coverage
         run: ripple run test.ci --fail-fast && ripple run coverage.merge && ripple run coverage.check
       - name: Update coverage trace file as artifact

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
       - name: Bootstrap packages
         run: |
           dart pub get
@@ -79,7 +79,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
       - name: Bootstrap packages
         run: |
           dart pub get
@@ -105,7 +105,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
       - name: Bootstrap packages
         run: |
           dart pub get

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
       - name: Bootstrap packages
         run: |
           dart pub get
@@ -79,7 +79,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
       - name: Bootstrap packages
         run: |
           dart pub get
@@ -105,7 +105,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
       - name: Bootstrap packages
         run: |
           dart pub get

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- {{dart}} pub get
+          ripple exec --fail-fast -- "{{dart}}" pub get
       - name: Format and analyze
         run: ripple run format.ci && ripple run analyze.ci --fail-fast
 
@@ -83,7 +83,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- {{dart}} pub get
+          ripple exec --fail-fast -- "{{dart}}" pub get
       - name: Verify up-to-date generated source files
         working-directory: packages/coverde_cli/
         run: dart test --run-skipped -t ci-only test/ensure_up_to_date_src_gen_test.dart
@@ -109,7 +109,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- {{dart}} pub get
+          ripple exec --fail-fast -- "{{dart}}" pub get
       - name: Run tests, merge tests if needed, and check 100% coverage
         run: ripple run test.ci --fail-fast && ripple run coverage.merge && ripple run coverage.check
       - name: Update coverage trace file as artifact

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- dart pub get
+          ripple exec --fail-fast -- {{dart}} pub get
       - name: Format and analyze
         run: ripple run format.ci && ripple run analyze.ci --fail-fast
 
@@ -83,7 +83,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- dart pub get
+          ripple exec --fail-fast -- {{dart}} pub get
       - name: Verify up-to-date generated source files
         working-directory: packages/coverde_cli/
         run: dart test --run-skipped -t ci-only test/ensure_up_to_date_src_gen_test.dart
@@ -109,7 +109,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- dart pub get
+          ripple exec --fail-fast -- {{dart}} pub get
       - name: Run tests, merge tests if needed, and check 100% coverage
         run: ripple run test.ci --fail-fast && ripple run coverage.merge && ripple run coverage.check
       - name: Update coverage trace file as artifact

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
       - name: Bootstrap packages
         run: |
           dart pub get

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,6 +31,6 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- dart pub get
+          ripple exec --fail-fast -- {{dart}} pub get
       - name: Run E2E tests
         run: ripple run test.e2e.ci --fail-fast

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,6 +31,6 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- {{dart}} pub get
+          ripple exec --fail-fast -- "{{dart}}" pub get
       - name: Run E2E tests
         run: ripple run test.e2e.ci --fail-fast

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,6 +29,6 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: ripple run get.ci --fail-fast
+        run: ripple run get --fail-fast
       - name: Run E2E tests
         run: ripple run test.e2e.ci --fail-fast

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,8 +29,6 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: |
-          dart pub get
-          ripple exec --fail-fast -- '{{dart}}' pub get
+        run: ripple run get.ci --fail-fast
       - name: Run E2E tests
         run: ripple run test.e2e.ci --fail-fast

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
       - name: Bootstrap packages
         run: |
           dart pub get

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -27,10 +27,10 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- "{{dart}}" pub get
+          ripple exec --fail-fast -- '{{dart}}' pub get
       - name: Run E2E tests
         run: ripple run test.e2e.ci --fail-fast

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
 
       - name: Bootstrap packages
         run: |

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- {{dart}} pub get
+          ripple exec --fail-fast -- "{{dart}}" pub get
 
       - name: Configure git author
         run: |

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -44,9 +44,7 @@ jobs:
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
 
       - name: Bootstrap packages
-        run: |
-          dart pub get
-          ripple exec --fail-fast -- '{{dart}}' pub get
+        run: ripple run get.ci --fail-fast
 
       - name: Configure git author
         run: |

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -41,12 +41,12 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
 
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- "{{dart}}" pub get
+          ripple exec --fail-fast -- '{{dart}}' pub get
 
       - name: Configure git author
         run: |

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -44,7 +44,7 @@ jobs:
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
 
       - name: Bootstrap packages
-        run: ripple run get.ci --fail-fast
+        run: ripple run get --fail-fast
 
       - name: Configure git author
         run: |

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- dart pub get
+          ripple exec --fail-fast -- {{dart}} pub get
 
       - name: Configure git author
         run: |

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
 
       - name: Bootstrap packages
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -62,7 +62,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
       - name: Bootstrap packages
         run: |
           dart pub get
@@ -116,7 +116,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
       - name: Bootstrap packages
         run: |
           dart pub get

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -64,7 +64,7 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: ripple run get.ci --fail-fast
+        run: ripple run get --fail-fast
       - name: Install webp
         run: sudo apt-get install -y webp
       - name: Format and analyze
@@ -116,7 +116,7 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: ripple run get.ci --fail-fast
+        run: ripple run get --fail-fast
       - name: Verify release tag on HEAD
         env:
           PACKAGE: ${{ inputs.package }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -62,11 +62,11 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- "{{dart}}" pub get
+          ripple exec --fail-fast -- '{{dart}}' pub get
       - name: Install webp
         run: sudo apt-get install -y webp
       - name: Format and analyze
@@ -77,7 +77,7 @@ jobs:
         run: |
           ripple run test.ci --fail-fast
           ripple run pub-score.local --fail-fast
-          ripple exec --group publishable --fail-fast -- "{{dart}}" pub publish --dry-run
+          ripple exec --group publishable --fail-fast -- '{{dart}}' pub publish --dry-run
 
   publish:
     name: Publish (${{ inputs.package }})
@@ -116,11 +116,11 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- "{{dart}}" pub get
+          ripple exec --fail-fast -- '{{dart}}' pub get
       - name: Verify release tag on HEAD
         env:
           PACKAGE: ${{ inputs.package }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- dart pub get
+          ripple exec --fail-fast -- {{dart}} pub get
       - name: Install webp
         run: sudo apt-get install -y webp
       - name: Format and analyze
@@ -77,7 +77,7 @@ jobs:
         run: |
           ripple run test.ci --fail-fast
           ripple run pub-score.local --fail-fast
-          ripple exec --group publishable --fail-fast -- dart pub publish --dry-run
+          ripple exec --group publishable --fail-fast -- {{dart}} pub publish --dry-run
 
   publish:
     name: Publish (${{ inputs.package }})
@@ -120,7 +120,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- dart pub get
+          ripple exec --fail-fast -- {{dart}} pub get
       - name: Verify release tag on HEAD
         env:
           PACKAGE: ${{ inputs.package }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- {{dart}} pub get
+          ripple exec --fail-fast -- "{{dart}}" pub get
       - name: Install webp
         run: sudo apt-get install -y webp
       - name: Format and analyze
@@ -77,7 +77,7 @@ jobs:
         run: |
           ripple run test.ci --fail-fast
           ripple run pub-score.local --fail-fast
-          ripple exec --group publishable --fail-fast -- {{dart}} pub publish --dry-run
+          ripple exec --group publishable --fail-fast -- "{{dart}}" pub publish --dry-run
 
   publish:
     name: Publish (${{ inputs.package }})
@@ -120,7 +120,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- {{dart}} pub get
+          ripple exec --fail-fast -- "{{dart}}" pub get
       - name: Verify release tag on HEAD
         env:
           PACKAGE: ${{ inputs.package }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -64,9 +64,7 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: |
-          dart pub get
-          ripple exec --fail-fast -- '{{dart}}' pub get
+        run: ripple run get.ci --fail-fast
       - name: Install webp
         run: sudo apt-get install -y webp
       - name: Format and analyze
@@ -118,9 +116,7 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: |
-          dart pub get
-          ripple exec --fail-fast -- '{{dart}}' pub get
+        run: ripple run get.ci --fail-fast
       - name: Verify release tag on HEAD
         env:
           PACKAGE: ${{ inputs.package }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -62,7 +62,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
       - name: Bootstrap packages
         run: |
           dart pub get
@@ -116,7 +116,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
       - name: Bootstrap packages
         run: |
           dart pub get

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -52,7 +52,7 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: ripple run get.ci --fail-fast
+        run: ripple run get --fail-fast
       - name: Verify release manifest changes match title
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -126,7 +126,7 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: ripple run get.ci --fail-fast
+        run: ripple run get --fail-fast
       - name: Install webp
         run: sudo apt-get install -y webp
       - name: Format and analyze

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -50,7 +50,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
       - name: Bootstrap packages
         run: |
           dart pub get
@@ -126,7 +126,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
       - name: Bootstrap packages
         run: |
           dart pub get

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- dart pub get
+          ripple exec --fail-fast -- {{dart}} pub get
       - name: Verify release manifest changes match title
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -130,7 +130,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- dart pub get
+          ripple exec --fail-fast -- {{dart}} pub get
       - name: Install webp
         run: sudo apt-get install -y webp
       - name: Format and analyze
@@ -143,7 +143,7 @@ jobs:
         run: |
           ripple run test.ci --fail-fast
           ripple run pub-score.local --fail-fast
-          ripple exec --group publishable --fail-fast -- dart pub publish --dry-run
+          ripple exec --group publishable --fail-fast -- {{dart}} pub publish --dry-run
       - name: Set step summary
         if: always()
         env:

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -50,7 +50,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
       - name: Bootstrap packages
         run: |
           dart pub get
@@ -126,7 +126,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
       - name: Bootstrap packages
         run: |
           dart pub get

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -50,11 +50,11 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- "{{dart}}" pub get
+          ripple exec --fail-fast -- '{{dart}}' pub get
       - name: Verify release manifest changes match title
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -126,11 +126,11 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- "{{dart}}" pub get
+          ripple exec --fail-fast -- '{{dart}}' pub get
       - name: Install webp
         run: sudo apt-get install -y webp
       - name: Format and analyze
@@ -143,7 +143,7 @@ jobs:
         run: |
           ripple run test.ci --fail-fast
           ripple run pub-score.local --fail-fast
-          ripple exec --group publishable --fail-fast -- "{{dart}}" pub publish --dry-run
+          ripple exec --group publishable --fail-fast -- '{{dart}}' pub publish --dry-run
       - name: Set step summary
         if: always()
         env:

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- {{dart}} pub get
+          ripple exec --fail-fast -- "{{dart}}" pub get
       - name: Verify release manifest changes match title
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -130,7 +130,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- {{dart}} pub get
+          ripple exec --fail-fast -- "{{dart}}" pub get
       - name: Install webp
         run: sudo apt-get install -y webp
       - name: Format and analyze
@@ -143,7 +143,7 @@ jobs:
         run: |
           ripple run test.ci --fail-fast
           ripple run pub-score.local --fail-fast
-          ripple exec --group publishable --fail-fast -- {{dart}} pub publish --dry-run
+          ripple exec --group publishable --fail-fast -- "{{dart}}" pub publish --dry-run
       - name: Set step summary
         if: always()
         env:

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -52,9 +52,7 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: |
-          dart pub get
-          ripple exec --fail-fast -- '{{dart}}' pub get
+        run: ripple run get.ci --fail-fast
       - name: Verify release manifest changes match title
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -128,9 +126,7 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: |
-          dart pub get
-          ripple exec --fail-fast -- '{{dart}}' pub get
+        run: ripple run get.ci --fail-fast
       - name: Install webp
         run: sudo apt-get install -y webp
       - name: Format and analyze

--- a/.github/workflows/resolve_readmes.yaml
+++ b/.github/workflows/resolve_readmes.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- {{dart}} pub get
+          ripple exec --fail-fast -- "{{dart}}" pub get
       - name: Resolve CLI README file
         run: ripple run docs.cli
       - name: Create PR

--- a/.github/workflows/resolve_readmes.yaml
+++ b/.github/workflows/resolve_readmes.yaml
@@ -27,7 +27,7 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: ripple run get.ci --fail-fast
+        run: ripple run get --fail-fast
       - name: Resolve CLI README file
         run: ripple run docs.cli
       - name: Create PR

--- a/.github/workflows/resolve_readmes.yaml
+++ b/.github/workflows/resolve_readmes.yaml
@@ -25,11 +25,11 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- "{{dart}}" pub get
+          ripple exec --fail-fast -- '{{dart}}' pub get
       - name: Resolve CLI README file
         run: ripple run docs.cli
       - name: Create PR

--- a/.github/workflows/resolve_readmes.yaml
+++ b/.github/workflows/resolve_readmes.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
       - name: Bootstrap packages
         run: |
           dart pub get

--- a/.github/workflows/resolve_readmes.yaml
+++ b/.github/workflows/resolve_readmes.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Bootstrap packages
         run: |
           dart pub get
-          ripple exec --fail-fast -- dart pub get
+          ripple exec --fail-fast -- {{dart}} pub get
       - name: Resolve CLI README file
         run: ripple run docs.cli
       - name: Create PR

--- a/.github/workflows/resolve_readmes.yaml
+++ b/.github/workflows/resolve_readmes.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: ./.github/actions/install-dart-cli
         with:
           package: >-
-            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}
+            ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}
       - name: Bootstrap packages
         run: |
           dart pub get

--- a/.github/workflows/resolve_readmes.yaml
+++ b/.github/workflows/resolve_readmes.yaml
@@ -27,9 +27,7 @@ jobs:
           package: >-
             ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}
       - name: Bootstrap packages
-        run: |
-          dart pub get
-          ripple exec --fail-fast -- '{{dart}}' pub get
+        run: ripple run get.ci --fail-fast
       - name: Resolve CLI README file
         run: ripple run docs.cli
       - name: Create PR

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # Coverage
 /coverage/
 
+# Ripple
+/ripple_overrides.yaml
+
 # Melos
 /**/.idea/
 /**/melos_overrides.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,7 @@ Highest matching component wins. A breaking type not listed as `type!` falls bac
 
 `release.check` in [`ripple.yaml`](ripple.yaml) is an unscoped `run:` gate and **rejects** `RIPPLE_PACKAGES`. Use it locally for the full repo.
 
-CI runs the same steps: `format.ci` and `analyze.ci` stay repo-wide; `RIPPLE_PACKAGES=coverde` scopes `test.ci`, `pub-score.local`, and `ripple exec --group publishable -- {{dart}} pub publish --dry-run`.
+CI runs the same steps: `format.ci` and `analyze.ci` stay repo-wide; `RIPPLE_PACKAGES=coverde` scopes `test.ci`, `pub-score.local`, and `ripple exec --group publishable -- "{{dart}}" pub publish --dry-run`.
 
 ### Prepare tool flags
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,18 @@ If you can include screenshots, trace data or any additional context, it could b
 
 ### Pre-requisites
 
-- [Dart SDK][dart_link] - min version: 3.5.0
+- [Dart SDK][dart_link] — the published CLI advertises `>=3.5.0`. **Developing this repo needs Dart 3.13** because tools and CLI e2e depend on `very_good_analysis` 11. The published constraint stays `>=3.5.0`.
 - Ripple — package discovery and script runner. Install the pinned CLI:
   ```bash
   dart install 'ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}'
   ```
+- Optional local Dart binary via a gitignored `ripple_overrides.yaml` (do not commit it). CI uses PATH `dart` and needs no overlay:
+
+```yaml
+# ripple_overrides.yaml
+replacements:
+  dart: fvm dart
+```
 
 Bootstrap after clone:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ If you can include screenshots, trace data or any additional context, it could b
 - [Dart SDK][dart_link] - min version: 3.5.0
 - Ripple — package discovery and script runner. Install the pinned CLI:
   ```bash
-  dart install 'ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 364f05aa0db1dd2a0f8a70856f312cfb1a6df73a}}'
+  dart install 'ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}'
   ```
 
 Bootstrap after clone:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,7 @@ Highest matching component wins. A breaking type not listed as `type!` falls bac
 
 `release.check` in [`ripple.yaml`](ripple.yaml) is an unscoped `run:` gate and **rejects** `RIPPLE_PACKAGES`. Use it locally for the full repo.
 
-CI runs the same steps: `format.ci` and `analyze.ci` stay repo-wide; `RIPPLE_PACKAGES=coverde` scopes `test.ci`, `pub-score.local`, and `ripple exec --group publishable -- dart pub publish --dry-run`.
+CI runs the same steps: `format.ci` and `analyze.ci` stay repo-wide; `RIPPLE_PACKAGES=coverde` scopes `test.ci`, `pub-score.local`, and `ripple exec --group publishable -- {{dart}} pub publish --dry-run`.
 
 ### Prepare tool flags
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ If you can include screenshots, trace data or any additional context, it could b
 - [Dart SDK][dart_link] — the published CLI advertises `>=3.5.0`. **Developing this repo needs Dart 3.13** because tools and CLI e2e depend on `very_good_analysis` 11. The published constraint stays `>=3.5.0`.
 - Ripple — package discovery and script runner. Install the pinned CLI:
   ```bash
-  dart install 'ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: 72a3a97b2615fe1b133573320bdb187335f8adf4}}'
+  dart install 'ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}'
   ```
 - Optional local Dart binary via a gitignored `ripple_overrides.yaml` (do not commit it). CI uses PATH `dart` and needs no overlay:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,15 +40,17 @@ If you can include screenshots, trace data or any additional context, it could b
 - [Dart SDK][dart_link] — the published CLI advertises `>=3.5.0`. **Developing this repo needs Dart 3.13** because tools and CLI e2e depend on `very_good_analysis` 11. The published constraint stays `>=3.5.0`.
 - Ripple — package discovery and script runner. Install the pinned CLI:
   ```bash
-  dart install 'ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: c7c50f41fd43570316a1d85bdcacf31e0db4f2df}}'
+  dart install 'ripple_cli@{git: {url: https://github.com/mrverdant13/ripple.git, ref: ccc3d80a9ff466b4219ff969b06361c7b7d7e076}}'
   ```
-- Optional local Dart binary via a gitignored `ripple_overrides.yaml` (do not commit it). CI uses PATH `dart` and needs no overlay:
+- Optional local Dart binary via a gitignored `ripple_overrides.yaml` (do not commit it). CI uses PATH `dart` and needs no overlay. A local `dart:` overlay also flows into `coverde: "{{dart}} run coverde"` in [`ripple.yaml`](ripple.yaml):
 
 ```yaml
 # ripple_overrides.yaml
 replacements:
   dart: fvm dart
 ```
+
+Shell `ripple exec` must quote each `{{key}}` token (`'{{dart}}'`) so PowerShell does not treat it as a script block. Quote only the placeholder, not the rest of the command.
 
 Bootstrap after clone:
 
@@ -169,7 +171,7 @@ Highest matching component wins. A breaking type not listed as `type!` falls bac
 
 `release.check` in [`ripple.yaml`](ripple.yaml) is an unscoped `run:` gate and **rejects** `RIPPLE_PACKAGES`. Use it locally for the full repo.
 
-CI runs the same steps: `format.ci` and `analyze.ci` stay repo-wide; `RIPPLE_PACKAGES=coverde` scopes `test.ci`, `pub-score.local`, and `ripple exec --group publishable -- "{{dart}}" pub publish --dry-run`.
+CI runs the same steps: `format.ci` and `analyze.ci` stay repo-wide; `RIPPLE_PACKAGES=coverde` scopes `test.ci`, `pub-score.local`, and `ripple exec --group publishable -- '{{dart}}' pub publish --dry-run`.
 
 ### Prepare tool flags
 

--- a/ripple.yaml
+++ b/ripple.yaml
@@ -33,9 +33,6 @@ scripts:
   get:
     description: Get all packages
     exec: "{{dart}} pub get"
-  get.ci:
-    description: Get all packages (CI)
-    exec: "{{dart}} pub get"
 
   format:
     description: Format a package

--- a/ripple.yaml
+++ b/ripple.yaml
@@ -27,6 +27,7 @@ packages:
 
 replacements:
   dart: dart
+  coverde: "{{dart}} run coverde"
 
 scripts:
   get:
@@ -60,7 +61,7 @@ scripts:
   test:
     description: Run tests and generate coverage trace file for a package
     exec:
-      - "{{dart}} run coverde optimize-tests --exclude '**/fixtures/**' --include test/**_test.dart --output test/optimized_test.dart"
+      - "{{coverde}} optimize-tests --exclude '**/fixtures/**' --include test/**_test.dart --output test/optimized_test.dart"
       - "{{dart}} test --color --coverage-path coverage/lcov.info --coverage-package ${RIPPLE_PACKAGE_NAME} --exclude-tags ci-only --reporter expanded --test-randomize-ordering-seed random test/optimized_test.dart"
     filters:
       - dependsOn: [test]
@@ -68,7 +69,7 @@ scripts:
   test.ci:
     description: Run tests for all packages (CI)
     exec:
-      - "{{dart}} run coverde optimize-tests --exclude '**/fixtures/**' --include test/**_test.dart --output test/optimized_test.dart"
+      - "{{coverde}} optimize-tests --exclude '**/fixtures/**' --include test/**_test.dart --output test/optimized_test.dart"
       - "{{dart}} test --coverage-path coverage/lcov.info --coverage-package ${RIPPLE_PACKAGE_NAME} --exclude-tags ci-only --reporter expanded --test-randomize-ordering-seed random test/optimized_test.dart"
     filters:
       - dependsOn: [test]
@@ -77,14 +78,14 @@ scripts:
   coverage.merge:
     description: Merge all packages coverage trace files
     run:
-      - "{{dart}} run coverde rm --no-dry-run ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info"
-      - "ripple exec --file-exists coverage/lcov.info -- \"{{dart}}\" run coverde transform --input coverage/lcov.info --output ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info --transformations relative=${RIPPLE_ROOT_PATH} --transformations skip-by-glob='**/*.asset.dart'"
+      - "{{coverde}} rm --no-dry-run ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info"
+      - "ripple exec --file-exists coverage/lcov.info -- '{{coverde}}' transform --input coverage/lcov.info --output ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info --transformations relative=${RIPPLE_ROOT_PATH} --transformations skip-by-glob='**/*.asset.dart'"
   coverage.check:
     description: Check test coverage
-    run: "{{dart}} run coverde check --input ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info 100"
+    run: "{{coverde}} check --input ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info 100"
   coverage.report:
     description: Generate HTML coverage report
-    run: "{{dart}} run coverde report --input ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info --output ${RIPPLE_ROOT_PATH}/coverage/html/"
+    run: "{{coverde}} report --input ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info --output ${RIPPLE_ROOT_PATH}/coverage/html/"
 
   test.e2e:
     description: Run E2E tests
@@ -133,7 +134,7 @@ scripts:
       - ripple run analyze.ci --fail-fast
       - ripple run test.ci --fail-fast
       - ripple run pub-score.local --fail-fast
-      - "ripple exec --group publishable --fail-fast -- \"{{dart}}\" pub publish --dry-run"
+      - "ripple exec --group publishable --fail-fast -- '{{dart}}' pub publish --dry-run"
 
   docs.cli:
     description: Resolve CLI README file

--- a/ripple.yaml
+++ b/ripple.yaml
@@ -25,28 +25,31 @@ packages:
       - tools/pub_score_checker
       - tools/readmes_resolver
 
+replacements:
+  dart: dart
+
 scripts:
   get:
     description: Get all packages
-    exec: dart pub get
+    exec: "{{dart}} pub get"
 
   format:
     description: Format a package
-    exec: dart format .
+    exec: "{{dart}} format ."
   format.ci:
     description: Format all packages (CI)
-    exec: dart format --set-exit-if-changed .
+    exec: "{{dart}} format --set-exit-if-changed ."
 
   analyze:
     description: Analyze a package
-    exec: dart analyze .
+    exec: "{{dart}} analyze ."
   analyze.ci:
     description: Analyze all packages (CI)
-    exec: dart analyze --fatal-infos --fatal-warnings .
+    exec: "{{dart}} analyze --fatal-infos --fatal-warnings ."
 
   gen:
     description: Run code generation for a package
-    exec: dart run build_runner build --delete-conflicting-outputs
+    exec: "{{dart}} run build_runner build --delete-conflicting-outputs"
     filters:
       - dependsOn: [build_runner]
 
@@ -57,16 +60,16 @@ scripts:
   test:
     description: Run tests and generate coverage trace file for a package
     exec:
-      - dart run coverde optimize-tests --exclude '**/fixtures/**' --include test/**_test.dart --output test/optimized_test.dart
-      - dart test --color --coverage-path coverage/lcov.info --coverage-package ${RIPPLE_PACKAGE_NAME} --exclude-tags ci-only --reporter expanded --test-randomize-ordering-seed random test/optimized_test.dart
+      - "{{dart}} run coverde optimize-tests --exclude '**/fixtures/**' --include test/**_test.dart --output test/optimized_test.dart"
+      - "{{dart}} test --color --coverage-path coverage/lcov.info --coverage-package ${RIPPLE_PACKAGE_NAME} --exclude-tags ci-only --reporter expanded --test-randomize-ordering-seed random test/optimized_test.dart"
     filters:
       - dependsOn: [test]
       - dirExists: [test]
   test.ci:
     description: Run tests for all packages (CI)
     exec:
-      - dart run coverde optimize-tests --exclude '**/fixtures/**' --include test/**_test.dart --output test/optimized_test.dart
-      - dart test --coverage-path coverage/lcov.info --coverage-package ${RIPPLE_PACKAGE_NAME} --exclude-tags ci-only --reporter expanded --test-randomize-ordering-seed random test/optimized_test.dart
+      - "{{dart}} run coverde optimize-tests --exclude '**/fixtures/**' --include test/**_test.dart --output test/optimized_test.dart"
+      - "{{dart}} test --coverage-path coverage/lcov.info --coverage-package ${RIPPLE_PACKAGE_NAME} --exclude-tags ci-only --reporter expanded --test-randomize-ordering-seed random test/optimized_test.dart"
     filters:
       - dependsOn: [test]
       - dirExists: [test]
@@ -74,20 +77,20 @@ scripts:
   coverage.merge:
     description: Merge all packages coverage trace files
     run:
-      - dart run coverde rm --no-dry-run ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info
-      - ripple exec --file-exists coverage/lcov.info -- dart run coverde transform --input coverage/lcov.info --output ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info --transformations relative=${RIPPLE_ROOT_PATH} --transformations skip-by-glob='**/*.asset.dart'
+      - "{{dart}} run coverde rm --no-dry-run ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info"
+      - "ripple exec --file-exists coverage/lcov.info -- {{dart}} run coverde transform --input coverage/lcov.info --output ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info --transformations relative=${RIPPLE_ROOT_PATH} --transformations skip-by-glob='**/*.asset.dart'"
   coverage.check:
     description: Check test coverage
-    run: dart run coverde check --input ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info 100
+    run: "{{dart}} run coverde check --input ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info 100"
   coverage.report:
     description: Generate HTML coverage report
-    run: dart run coverde report --input ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info --output ${RIPPLE_ROOT_PATH}/coverage/html/
+    run: "{{dart}} run coverde report --input ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info --output ${RIPPLE_ROOT_PATH}/coverage/html/"
 
   test.e2e:
     description: Run E2E tests
     exec:
       - git clean -dfX .
-      - dart test --color --run-skipped --tags e2e e2e
+      - "{{dart}} test --color --run-skipped --tags e2e e2e"
     filters:
       - group: e2e
       - dirExists: [e2e]
@@ -95,19 +98,19 @@ scripts:
     description: Run E2E tests for all packages (CI)
     exec:
       - git clean -dfX .
-      - dart test --run-skipped --tags e2e e2e
+      - "{{dart}} test --run-skipped --tags e2e e2e"
     filters:
       - group: e2e
       - dirExists: [e2e]
 
   pub-score.local:
     description: Check local pub.dev score for publishable packages
-    exec: dart run ${RIPPLE_ROOT_PATH}/tools/pub_score_checker/bin/pub_score_checker.dart check_pub_score local --markdown-output ${RIPPLE_PACKAGE_PATH}/.dart_tool/local_pub_score.md --package-path ${RIPPLE_PACKAGE_PATH} --threshold 0
+    exec: "{{dart}} run ${RIPPLE_ROOT_PATH}/tools/pub_score_checker/bin/pub_score_checker.dart check_pub_score local --markdown-output ${RIPPLE_PACKAGE_PATH}/.dart_tool/local_pub_score.md --package-path ${RIPPLE_PACKAGE_PATH} --threshold 0"
     filters:
       - group: publishable
   pub-score.remote:
     description: Check remote pub.dev score for publishable packages
-    exec: dart run ${RIPPLE_ROOT_PATH}/tools/pub_score_checker/bin/pub_score_checker.dart check_pub_score remote --markdown-output ${RIPPLE_PACKAGE_PATH}/.dart_tool/remote_pub_score.md --package-name ${RIPPLE_PACKAGE_NAME} --threshold 0
+    exec: "{{dart}} run ${RIPPLE_ROOT_PATH}/tools/pub_score_checker/bin/pub_score_checker.dart check_pub_score remote --markdown-output ${RIPPLE_PACKAGE_PATH}/.dart_tool/remote_pub_score.md --package-name ${RIPPLE_PACKAGE_NAME} --threshold 0"
     filters:
       - group: publishable
 
@@ -116,8 +119,8 @@ scripts:
       Bump version and changelog for a single package release. Set
       RIPPLE_PACKAGES=<package> to scope to one package.
     exec:
-      - dart run ${RIPPLE_ROOT_PATH}/tools/prepare_package_release/prepare_package_release.dart --cwd ${RIPPLE_PACKAGE_PATH} --tag-format '{name}-v{version}' --scopes coverde-cli --commit-types feat,fix,docs,refactor,perf,test,build,chore --major-types= --minor-types feat!,fix! --patch-types feat,fix --build-types docs,refactor,perf,test,build,chore --apply
-      - dart run build_runner build --delete-conflicting-outputs
+      - "{{dart}} run ${RIPPLE_ROOT_PATH}/tools/prepare_package_release/prepare_package_release.dart --cwd ${RIPPLE_PACKAGE_PATH} --tag-format '{name}-v{version}' --scopes coverde-cli --commit-types feat,fix,docs,refactor,perf,test,build,chore --major-types= --minor-types feat!,fix! --patch-types feat,fix --build-types docs,refactor,perf,test,build,chore --apply"
+      - "{{dart}} run build_runner build --delete-conflicting-outputs"
     filters:
       - group: publishable
 
@@ -130,11 +133,11 @@ scripts:
       - ripple run analyze.ci --fail-fast
       - ripple run test.ci --fail-fast
       - ripple run pub-score.local --fail-fast
-      - ripple exec --group publishable --fail-fast -- dart pub publish --dry-run
+      - "ripple exec --group publishable --fail-fast -- {{dart}} pub publish --dry-run"
 
   docs.cli:
     description: Resolve CLI README file
-    run: dart run ${RIPPLE_ROOT_PATH}/tools/readmes_resolver/lib/resolve_root_readme.dart --example-dirs=${RIPPLE_ROOT_PATH}/packages/coverde_cli/doc/examples/browser/ --example-dirs=${RIPPLE_ROOT_PATH}/packages/coverde_cli/doc/examples/terminal/ --example-dirs=${RIPPLE_ROOT_PATH}/packages/coverde_cli/doc/examples/markdown/ --readme=${RIPPLE_ROOT_PATH}/packages/coverde_cli/README.md
+    run: "{{dart}} run ${RIPPLE_ROOT_PATH}/tools/readmes_resolver/lib/resolve_root_readme.dart --example-dirs=${RIPPLE_ROOT_PATH}/packages/coverde_cli/doc/examples/browser/ --example-dirs=${RIPPLE_ROOT_PATH}/packages/coverde_cli/doc/examples/terminal/ --example-dirs=${RIPPLE_ROOT_PATH}/packages/coverde_cli/doc/examples/markdown/ --readme=${RIPPLE_ROOT_PATH}/packages/coverde_cli/README.md"
 
   clean:
     description: Deep clean-up

--- a/ripple.yaml
+++ b/ripple.yaml
@@ -28,6 +28,7 @@ packages:
 replacements:
   dart: dart
   coverde: "{{dart}} run coverde"
+  check_pub_score: "{{dart}} run ${RIPPLE_ROOT_PATH}/tools/pub_score_checker/bin/pub_score_checker.dart check_pub_score"
 
 scripts:
   get:
@@ -106,12 +107,12 @@ scripts:
 
   pub-score.local:
     description: Check local pub.dev score for publishable packages
-    exec: "{{dart}} run ${RIPPLE_ROOT_PATH}/tools/pub_score_checker/bin/pub_score_checker.dart check_pub_score local --markdown-output ${RIPPLE_PACKAGE_PATH}/.dart_tool/local_pub_score.md --package-path ${RIPPLE_PACKAGE_PATH} --threshold 0"
+    exec: "{{check_pub_score}} local --markdown-output ${RIPPLE_PACKAGE_PATH}/.dart_tool/local_pub_score.md --package-path ${RIPPLE_PACKAGE_PATH} --threshold 0"
     filters:
       - group: publishable
   pub-score.remote:
     description: Check remote pub.dev score for publishable packages
-    exec: "{{dart}} run ${RIPPLE_ROOT_PATH}/tools/pub_score_checker/bin/pub_score_checker.dart check_pub_score remote --markdown-output ${RIPPLE_PACKAGE_PATH}/.dart_tool/remote_pub_score.md --package-name ${RIPPLE_PACKAGE_NAME} --threshold 0"
+    exec: "{{check_pub_score}} remote --markdown-output ${RIPPLE_PACKAGE_PATH}/.dart_tool/remote_pub_score.md --package-name ${RIPPLE_PACKAGE_NAME} --threshold 0"
     filters:
       - group: publishable
 

--- a/ripple.yaml
+++ b/ripple.yaml
@@ -33,6 +33,9 @@ scripts:
   get:
     description: Get all packages
     exec: "{{dart}} pub get"
+  get.ci:
+    description: Get all packages (CI)
+    exec: "{{dart}} pub get"
 
   format:
     description: Format a package

--- a/ripple.yaml
+++ b/ripple.yaml
@@ -78,7 +78,7 @@ scripts:
     description: Merge all packages coverage trace files
     run:
       - "{{dart}} run coverde rm --no-dry-run ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info"
-      - "ripple exec --file-exists coverage/lcov.info -- {{dart}} run coverde transform --input coverage/lcov.info --output ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info --transformations relative=${RIPPLE_ROOT_PATH} --transformations skip-by-glob='**/*.asset.dart'"
+      - "ripple exec --file-exists coverage/lcov.info -- \"{{dart}}\" run coverde transform --input coverage/lcov.info --output ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info --transformations relative=${RIPPLE_ROOT_PATH} --transformations skip-by-glob='**/*.asset.dart'"
   coverage.check:
     description: Check test coverage
     run: "{{dart}} run coverde check --input ${RIPPLE_ROOT_PATH}/coverage/filtered.lcov.info 100"
@@ -133,7 +133,7 @@ scripts:
       - ripple run analyze.ci --fail-fast
       - ripple run test.ci --fail-fast
       - ripple run pub-score.local --fail-fast
-      - "ripple exec --group publishable --fail-fast -- {{dart}} pub publish --dry-run"
+      - "ripple exec --group publishable --fail-fast -- \"{{dart}}\" pub publish --dry-run"
 
   docs.cli:
     description: Resolve CLI README file


### PR DESCRIPTION
## Summary
- Pin Ripple to `c7c50f4` so `{{dart}}` replacements, overlay files, and `--override` / `RIPPLE_OVERRIDE` are available (includes Windows quoting/test CI fixes from Ripple #28–#30).
- Wrap Ripple and workflow `dart` invocations as `{{dart}}`, defaulting to PATH `dart`.
- Ignore `ripple_overrides.yaml` and document the Dart 3.13 repo-dev floor plus an optional local overlay.

## Test plan
- [x] CI `min-conditions` and `test` jobs bootstrap with `ripple exec --fail-fast -- {{dart}} pub get`
- [x] `ripple run get`, `format.ci`, and `analyze.ci` still succeed on latest Dart
- [x] Banners show the expanded `dart` argv; behavior is unchanged
- [x] No package source or VGA changes