### PR TITLE
ci: check out repo before Codecov upload

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,6 +140,10 @@ jobs:
     if: needs.min-conditions.outputs.publish_coverage == 'true'
     runs-on: ubuntu-latest
     steps:
+      # Codecov needs a git checkout so the CLI can build the file network and
+      # map LCOV SF: paths; without it uploads succeed but reports are unusable.
+      - name: Check out repository
+        uses: actions/checkout@v7
       - name: Download coverage trace file artifacts
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
## Summary
- Add `actions/checkout` to the Codecov publish job so the CLI can build the git file network and map LCOV `SF:` paths.
- Fixes Codecov “Unusable report” after a successful upload (source/network mismatch with no checkout).

## Test plan
- [x] CI passes on this PR
- [x] After merge to `main`, the next “Publish coverage results” job logs a git versioning system (not `NoVersioningSystem`) and a large network file count
- [x] Matching commit on Codecov shows a usable report (no “Unusable report” banner)