### PR TITLE
chore(t-wait-for-pub-dev-version): add coverde path dep for Ripple test.ci

### DIFF
--- a/tools/wait_for_pub_dev_version/.gitignore
+++ b/tools/wait_for_pub_dev_version/.gitignore
@@ -5,3 +5,7 @@
 .packages
 build/
 pubspec.lock
+
+# Testing and coverage
+/coverage/
+/test/optimized_test.dart

--- a/tools/wait_for_pub_dev_version/pubspec.yaml
+++ b/tools/wait_for_pub_dev_version/pubspec.yaml
@@ -5,5 +5,7 @@ environment:
   sdk: ">=3.5.0 <4.0.0"
 
 dev_dependencies:
+  coverde:
+    path: ../../packages/coverde_cli
   test: ^1.25.0
   very_good_analysis: ^11.0.0


### PR DESCRIPTION
## Summary
- Add a path `coverde` dev dependency so `ripple run test.ci` can resolve `optimize-tests` from this package.
- Ignore generated `/coverage/` and `/test/optimized_test.dart` artifacts.

## Test plan
- [x] `dart pub get` in `tools/wait_for_pub_dev_version`
- [x] `dart test` in `tools/wait_for_pub_dev_version` (existing `release-tools` CI)