### PR TITLE
chore(t-prepare-package-release): add coverde path dep for Ripple test.ci

### DIFF
--- a/tools/prepare_package_release/.gitignore
+++ b/tools/prepare_package_release/.gitignore
@@ -5,3 +5,7 @@
 .packages
 build/
 pubspec.lock
+
+# Testing and coverage
+/coverage/
+/test/optimized_test.dart

--- a/tools/prepare_package_release/pubspec.yaml
+++ b/tools/prepare_package_release/pubspec.yaml
@@ -13,5 +13,7 @@ dependencies:
   yaml_edit: ^2.2.4
 
 dev_dependencies:
+  coverde:
+    path: ../../packages/coverde_cli
   test: ^1.25.0
   very_good_analysis: ^11.0.0


### PR DESCRIPTION
## Summary
- Add a path `coverde` dev dependency so `ripple run test.ci` can resolve `optimize-tests` from this package.
- Ignore generated `/coverage/` and `/test/optimized_test.dart` artifacts.

## Test plan
- [x] `dart pub get` in `tools/prepare_package_release`
- [x] `dart test` in `tools/prepare_package_release` (existing `release-tools` CI)