### PR TITLE
chore: include release tools in Ripple workspace

### DIFF
--- a/ripple.yaml
+++ b/ripple.yaml
@@ -11,8 +11,6 @@ packages:
     - '**/test/fixtures/**'
     - '**/e2e/fixtures/**'
     - '**/e2e/e2e/fixtures/**'
-    - tools/prepare_package_release
-    - tools/wait_for_pub_dev_version
     - tools/readmes_resolver/lib/sample_project
   groups:
     e2e:
@@ -26,6 +24,8 @@ packages:
       - tools/package_data_generator
       - tools/pub_score_checker
       - tools/readmes_resolver
+      - tools/prepare_package_release
+      - tools/wait_for_pub_dev_version
 
 replacements:
   dart: dart


### PR DESCRIPTION
## Summary
- Stop excluding `tools/prepare_package_release` and `tools/wait_for_pub_dev_version` from Ripple.
- Add both packages to `packages.groups.tools`.
- Keep `tools/readmes_resolver/lib/sample_project` excluded (fixture package).

Depends on #358 and #359 (already merged). Follow with #361 to drop the dedicated `release-tools` job.

## Test plan
- [x] `ripple run get --fail-fast`
- [x] `ripple run format.ci && ripple run analyze.ci --fail-fast`
- [x] `RIPPLE_PACKAGES=prepare_package_release,wait_for_pub_dev_version ripple run test.ci --fail-fast`
- [x] Confirm `release-tools` job still runs until #361 lands