### PR TITLE
ci: drop release-tools job now covered by Ripple

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,31 +57,6 @@ jobs:
       - name: Run min-SDK consumer smoke
         run: ripple run test.min-sdk --fail-fast
 
-  release-tools:
-    name: Test release tools (${{ matrix.package }})
-    runs-on: ubuntu-latest
-    needs: min-conditions
-    strategy:
-      fail-fast: false
-      matrix:
-        package:
-          - tools/prepare_package_release
-          - tools/wait_for_pub_dev_version
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v7
-      - name: Install dart
-        uses: dart-lang/setup-dart@v1
-      - name: Install dependencies
-        working-directory: ${{ matrix.package }}
-        run: dart pub get
-      - name: Format, analyze, and test
-        working-directory: ${{ matrix.package }}
-        run: >
-          dart format --set-exit-if-changed . &&
-          dart analyze --fatal-infos --fatal-warnings . &&
-          dart test
-
   src-gen:
     name: Ensure up-to-date source generation
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Remove the dedicated `release-tools` CI job.
- Those packages are covered by `format.ci` / `analyze.ci` / `test.ci` once #360 is merged.

**Merge after #360** so there is no gap in coverage.

## Test plan
- [x] Confirm #360 is merged first
- [x] Dart CI no longer runs `Test release tools`
- [x] `min-conditions` and `test` still cover `prepare_package_release` and `wait_for_pub_dev_version`